### PR TITLE
Final draft

### DIFF
--- a/srfi-170.html
+++ b/srfi-170.html
@@ -378,7 +378,7 @@ the specified file descriptor, effectively importing it into the
 Scheme world.
 In particular, the textual ports use the same character encoding applied
 by default in the underlying implementation.
-Note that <i>fdo-or-int</i> may be an exact integer
+Note that <i>fdo-or-int</i> can be an exact integer
 whether or not FDOs are disjoint from integers.
 <p>The <i>buffer-mode</i> argument, if present, is one of the constants <code>buffer/none</code>,
   <code>buffer/block</code> (the default), or <code>buffer/line</code>.
@@ -988,17 +988,17 @@ so the suffix is kept in this SRFI.</p>
 <p></p>
 <p>
 </p>
-<div><code>(terminal? <i>fdo-or-exact-int</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
+<div><code>(terminal? <i>port-or-fdo-or-exact-int</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
 <blockquote>
 Returns true if the argument is a file descriptor
-that is open on a terminal.
+or a port that is open on a terminal.
 Raises an exception if the underlying call to <code>isatty()</code> returns an error
 other than <code>ENOTTY</code>.
 This procedure is useful when writing programs that change their behavior
 when their standard input or output is a terminal.
 It is safe to call this operation
 on the result of <code>port-internal-fd</code>.
-The <i>fdo-or-exact-int</i> argument may be an exact integer,
+The <i>fdo-or-exact-int</i> argument can be an exact integer,
 whether or not FDOs are disjoint from integers.
 </blockquote>
 <h2>Implementation</h2>

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -302,11 +302,6 @@ performed on ports.
 As exceptions, <code>open-file</code> is provided, because
 it allows arguments that the Scheme standard does not.  It returns
 a file descriptor that can then be converted to a port.
-Likewise, <code>terminal?</code> in Section 3.12
-accepts an FDO as well as a port because it is often
-applied to the standard input (fd 0), standard output (1),
-or standard error(3), and it is possible that no port is open
-on any of these.
 </p>
 <div><code>(fdo-internal-fd <i>fdo</i>)</code> &nbsp;&rarr; <i>exact-int</i>&nbsp;&nbsp;</div>
 <p></p>
@@ -1006,16 +1001,15 @@ so the suffix is kept in this SRFI.</p>
 <p></p>
 <p>
 </p>
-<div><code>(terminal? <i>port-or-fdo</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
+<div><code>(terminal? <i>port</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
 <blockquote>
-Returns true if the argument is a port or a file descriptor
-that is open on a terminal.
+Returns true if the argument is a file descriptor that is open on a terminal.
 Raises an exception if the underlying call to <code>isatty()</code> returns an error
 other than <code>ENOTTY</code>.
 This procedure is useful when writing programs that change their behavior
 when their standard input or output is a terminal.
-It is safe to call this operation
-on the result of <code>port-internal-fdo</code>.
+Because it is expected to be called before doing input or output
+on the terminal, it accepts a port rather than an file descriptor object.
 </blockquote>
 <h2>Implementation</h2>
 

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -305,7 +305,8 @@ performed on ports.
 As exceptions, <code>open-file</code> is provided, because
 it allows arguments that the Scheme standard does not.  It returns
 a file descriptor that can then be converted to a port.
-LIkewise, <code>terminal?</code> accepts an FDO because it is often
+LIkewise, <code>terminal?</code> in Section 3.12
+accepts an FDO because it is often
 applied to the standard input (fd 0), standard output (1),
 or standard error(3), and it is possible that no port is open
 on any of these.
@@ -331,10 +332,11 @@ one or more of the following constants:
 <div><code>(port-internal-fd <i>port</i>)</code> &nbsp;&rarr; <i>fdo</i>&nbsp;&nbsp;</div>
 <p></p>
 <blockquote>
-<p>Returns the file descriptor used by <i>port</i> as an FDO,
-or <code>#f</code> if there is no such file descriptor.
-This procedure is made available in order to invoke
-P<small>OSIX</small> functions not provided by this SRFI.
+<p>Returns the file descriptor used by <i>port</i> as an FDO
+if the port is open on a file, socket,
+or similar source or sink that involves a file descriptor
+on a P<small>OSIX</small> system,
+or <code>#f</code> otherwise.
 <b>It should be used only when absolutely necessary.</b>
 If <i>fd</i> is closed with <code>close-fd</code>
 or otherwise, it is an error

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -219,12 +219,12 @@ different P<small>OSIX</small> systems, but the associated names
 (bound by a <code>#define</code> in the file
 <code>/usr/include/errno.h</code>) are the same for the most part,
 this function returns the name rather than the code.</p>
-<p>For example, ENOENT (a reference was made to a file or a directory
+<p>For example, <code>ENOENT</code> (a reference was made to a file or a directory
 that does not exist) almost always corresponds to an <code>errno</code>
 value of 2.
-But <code>ETIMEDOUT</code>, meaning that a TCP connection
-has been unresponsive for too long, is standardized by P<small>OSIX</small>,
-has a <code>errno</code> value of 110 on Linux, but 60 on FreeBSD and 116 on Cygwin.</p>
+But although <code>ETIMEDOUT</code> (meaning that a TCP connection
+has been unresponsive for too long) is standardized by P<small>OSIX</small>,
+it has a <code>errno</code> value of 110 on Linux, 60 on FreeBSD, and 116 on Cygwin.</p>
 </blockquote>
 <div><code>(posix-error-message <i>posix-error</i>)</code> &nbsp;&rarr; <i>string</i>
 <blockquote>

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -57,10 +57,6 @@ Operating System Interface standardized by the IEEE.  Not all of the
 functions of this SRFI are available on all operating systems.
 </p>
 
-<h2>Issues</h2>
-
-<p>None at present.</p>
-
 <h2>Rationale</h2>
 
 <p>The I/O and other environmental procedures provided by the various

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -163,12 +163,15 @@ either take no action and return some reasonable default value,
 or signal an exception.
 </p>
 <p>A Scheme implementation that supports both this SRFI and multiple
-threads of control must ensure that when a thread invokes a blocking I/O
-procedure defined below, only that thread is blocked and not any other
-concurrently running ones.
-Because Scheme threads may be multiplexed on top of P<small>OSIX</small>
-threads, the per-thread P<small>OSIX</small> functions may not do the
-right thing.
+threads of control must ensure that when a thread invokes a blocking
+procedure such as an R[4567]RS I/O operation, only that thread is
+blocked and not any other concurrently running ones.  Because
+a user-visible thread may be multiplexed on a single P<small>OSIX</small>
+thread, be in a 1:1 relationship with P<small>OSIX</small> threads,
+or run on different P<small>OSIX</small> threads at different times
+in its lifecycle, there can be no guarantees that a P<small>OSIX</small>
+function which is MT-Safe (that is, thread-safe in the sense of
+P<small>OSIX</small> threads) is safe for user-visible threads.
 </p>
 
 <p>
@@ -263,10 +266,7 @@ Ports are garbage-collected Scheme objects, not integers.
 When a port is garbage collected, it is effectively closed,
 but whether the underlying file descriptor is closed is left as an
 implementation detail.  Because file
-descriptors are just integers, it's impossible to garbage collect them &mdash; you
-wouldn't be able to close file descriptor 3 unless there were no 3's in the
-system, and you could further prove that your program would never again
-compute a 3. This is difficult at best.</p>
+descriptors are just integers, it's impossible to garbage collect them.</p>
 <p>
 If a Scheme program only used Scheme ports, and never actually used
 file descriptors, this would not be a problem. But Scheme code
@@ -399,9 +399,6 @@ The <i>permission-bits</i> for <code>create-directory</code>
 default to <code>#o775</code>, and for <code>create-fifo</code>
 to <code>#o664</code>, but are masked by the current umask.
 <p>
-</p><p>
-It is an error to try to create a hard link when <i>old-fname</i>
-and <i>new-fname</i> refer to the same file, and your file may be destroyed.
 </p></blockquote>
 
 <div><code>(read-symlink <i>fname</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>string</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>readlink()</code>&nbsp;</div>
@@ -412,6 +409,8 @@ and <i>new-fname</i> refer to the same file, and your file may be destroyed.
 and <i>new-fname</i> must type-match &mdash; either both directories,
 or both non-directories.
 This is required by the semantics of P<small>OSIX</small> <code>rename()</code>.<p>
+Calling <code>rename-file</code> on a symbolic link will rename the symbolic link,
+not the file it refers to.
 </p>
 <blockquote><i>Remark: </i>
 There is an unfortunate atomicity problem with the <code>rename-file</code>
@@ -640,6 +639,8 @@ and whose resolution does not involve <code>.</code>, <code>..</code>, or symlin
 the value of the environment variable <code>TMPDIR</code> concatenated with <code>"/<i>pid</i>"</code>
 if <code>TMPDIR</code> is set and to
 <code>"/tmp/<i>pid</i>"</code> otherwise, where <i>pid</i> is the id of the current process.
+On Windows, the temporary directory's name is not fixed, and must be obtained by the
+<code>GetTempPath()</code> API function.
 </blockquote>
 <div><code>(create-temp-file <i>[prefix]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>string</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
 <blockquote>Creates a new temporary file and returns its name.
@@ -827,7 +828,7 @@ and callers must be prepared to handle it.
 <div><code>(user-info:shell <i>user-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
 <blockquote>Returns the user name, user id, group id, home directory,
 and shell path stored in <i>user-info</i> respectively.
-Windows returns <code>#f</code> for any items it doesn't have.</blockquote>
+An implementation returns <code>#f</code> for any unavailable items.</blockquote>
 
 <div><code>(user-info:full-name <i>user-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
 <blockquote>Returns the contents of the <code>pw_gecos</code> field
@@ -968,10 +969,11 @@ so the suffix is kept in this SRFI.</p>
 <p></p>
 <p>
 </p>
-<div><code>(terminal? <i>port</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code>&nbsp;</div>
+<div><code>(terminal? <i>port-or-fd</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code>&nbsp;</div>
 <blockquote>
-Return true if the argument is a terminal.
-Raises an error if <code><i>port</i></code> is not a port,
+Returns true if the argument is a port or file descriptor
+that is open on a terminal.
+Raises an error if <code><i>port</i></code> is not a port or an exact integer,
 or if the underlying call to <code>isatty()</code> returns an error
 other than <code>ENOTTY</code>.
 This procedure is useful when writing programs that change their behavior

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -268,12 +268,6 @@ When a port is garbage collected, it is effectively closed,
 but whether the underlying file descriptor is closed is left as an
 implementation detail.  Because file
 descriptors are just integers, it's impossible to garbage collect them.</p>
-<p>Therefore, this SRFI introduces (or rather borrows from Chibi Scheme) the concept
-of a <i>file descriptor object</i> (FDO),
-which is the exact integer representing a file descriptor
-wrapped in a trivial record.
-This approach makes it possible to garbage-collect file descriptors after all.
-</p>
 <p>
 Ideally, a Scheme program could only use ports and not
 file descriptors.  But code written in any language, including Scheme,
@@ -299,24 +293,39 @@ to provide this SRFI.</p>
 <p>Consequently, this SRFI assumes that file descriptors will only
 be used at the edges of the program, and that most I/O operations will be
 performed on ports.
-As exceptions, <code>open-file</code> is provided, because
+As an exception, <code>open-file</code> is provided, because
 it allows arguments that the Scheme standard does not.  It returns
-a file descriptor that can then be converted to a port.
-</p>
-<div><code>(fdo-internal-fd <i>fdo</i>)</code> &nbsp;&rarr; <i>exact-int</i>&nbsp;&nbsp;</div>
-<p></p>
-<blockquote>
-<p>Returns the file descriptor encapsulated in <i>fdo</i> as an exact integer.
-<b>It should be used only when absolutely necessary,</b>
-such as when invoking a P<small>OSIX</small> API function
-not made available in this SRFI.
+a port of a specified type.
 </p>
 </blockquote>
 <p>
-<div><code>(open-file <i>fname flags [permission-bits]</i>)</code> &nbsp;&rarr; <i>fdo</i>&nbsp;&nbsp; P<small>OSIX</small> <code>open()</code></div>
+<div><code>binary-input</code></div>
+<div><code>textual-input</code></div>
+<div><code>binary-output</code></div>
+<div><code>textual-output</code></div>
+<div><code>binary-input/output</code></div>
+<blockquote>Symbols representing the type of port to be returned
+by <code>open-file</code> or <code>fd->port</code>.
+The textual ports use the same character encoding applied
+by default in the underlying implementation.
+The symbol <code>binary-input/output</code> represents a binary port
+that allows both input and output operations, as explained in
+<a href="https://srfi.schemers.org/srfi-181/srfi-181.html">SRFI 181</a>.
+</blockquote>
+<div><code>buffer-none</code></div>
+<div><code>buffer-block</code></div>
+<div><code>buffer-line</code></div>
 <blockquote>
-Opens the file named by <i>fname</i> and returns an FDO.
-<i>Permission-bits</i> defaults to <code>#o666</code>, but are masked by the current umask.
+Symbols representing, respectively: the absence of port buffering,
+where bytes are intended to appear from the source or at the destination as soon as possible;
+buffering with a block of implementation-dependent size;
+and buffering line by line, where a line is terminated
+by a newline byte <code>#xA</code>.
+</blockquote>
+<div><code>(open-file <i>fname port-type flags [permission-bits [buffer-mode] ]</i>)</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp; P<small>OSIX</small> <code>open()</code></div>
+<blockquote>
+Opens the file named by <i>fname</i> and returns a port
+of the type specified by <i>port-type</i>.
 <i>Flags</i> is an integer bitmask, composed by adding together
 one or more of the following constants:
 <code>open/read</code>,
@@ -327,79 +336,35 @@ one or more of the following constants:
 <code>open/exclusive</code>,
 <code>open/nofollow</code>,
 <code>open/truncate</code>.
+<i>Permission-bits</i> defaults to <code>#o666</code>, but are masked by the current umask.</p>
 <p>It is an error unless exactly one of the <code>open/read</code>, <code>open/write</code>, or
 <code>open/read+write</code> flags is provided.</p>
 </blockquote>
-<div><code>(port-internal-fdo <i>port</i>)</code> &nbsp;&rarr; <i>fdo</i>&nbsp;&nbsp;</div>
-<p></p>
+<div><code>(fd->port <i>fd port-type</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>
 <blockquote>
-<p>Returns the file descriptor used by <i>port</i> as an FDO
-if the port is open on a file, socket,
-or similar source or sink that involves a file descriptor
-on a P<small>OSIX</small> system,
-or <code>#f</code> otherwise.
-<b>It should be used only when absolutely necessary.</b>
-If <i>fd</i> is closed with <code>close-fd</code>
-or otherwise, it is an error
-to do any further operations on <i>port</i>.
-</p>
-</blockquote>
-<div><code>(close-fdo <i>fdo</i>)</code> &nbsp;&rarr; <i>undefined</i>&nbsp;&nbsp; P<small>OSIX</small> <code>close()</code></div>
-<p></p>
-<blockquote>
-<p>Closes the file descriptor encapsulated by <i>fdo</i>.
-If <i>fdo</i> is the internal file descriptor of a port, it is an error
-to do any further operations on that port.
-</p>
-</blockquote>
-
-<p>The following routines allow reasonably safe conversion between ports and file
-descriptors.
-More precisely, the port returned by the first four procedures
-contains a duplicate of the file descriptor passed to them,
-and the final procedure returns a file descriptor which is
-a duplicate of the one held by the port.</p>
-<p>It is the responsibility of the caller
-to make sure the file descriptor is closed.
-By the same token, the port may safely close its internal
-file descriptor when <code>close-port</code> is called on the port
-or when it is garbage-collected.
-However, as long as both are open,  the port and the file descriptor will share
-the same position, so that reads and writes on one are visible from the other.
-Therefore, <b>use caution</b> when reading or writing to the file descriptor
-(something this SRFI does not provide a mechanism for doing),
-especially in the presence of buffering.</p>
-<div><code>(fd->textual-input-port <i>fdo</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<div><code>(fd->binary-input-port <i>fdo</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i> &nbsp&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<div><code>(fd->textual-output-port <i>fdo</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<div><code>(fd->binary-output-port <i>fdo</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<blockquote>
-<p>These procedures wrap a newly created port around a duplicate of
+<p>This procedure wraps a newly created port around
 the specified file descriptor, effectively importing it into the
 Scheme world.
-In particular, the textual ports use the same character encoding applied
-by default in the underlying implementation.
-<p>The <i>buffer-mode</i> argument, if present, is one of the constants <code>buffer/none</code>,
-  <code>buffer/block</code> (the default), or <code>buffer/line</code>.
-  When <i>buffer-mode</i> is <code>buffer/none</code>,
-  bytes are intended to appear from the source or at the destination as soon as possible;
-  otherwise, bytes may be accumulated and transmitted as a block.
-  When <i>buffer-mode</i> is <code>buffer/block</code>, bytes are intended
-  to be transmitted as a fixed size block when a buffer is filled.
-  When <i>buffer-mode</i> is <code>buffer/line</code>, bytes are intended
-  to be transmitted as a block when a newline byte <code>#xA</code> is encountered.
+The most common use of this procedure is for a file descriptor other
+than 0, 1, 2 (standard input, standard output, standard error)
+that is already open when the Scheme program starts.
+It is an error if a port already exists that encapsulates <i>fd</i>.
 </p>
 </blockquote>
 
-<div><code>(port->fdo <i>port</i>)</code> &nbsp;&rarr; <i><i>fdo</i></i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-
+<div><code>(with-port-fd <i>port proc</i>)</code> &nbsp;&rarr; <i>unspecified</i>&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup ()</code></div>
+<p></p>
 <blockquote>
-<p>This procedure returns an FDO that has been duplicated
-from <i>port</i>, effectively exporting it from the Scheme world.
-Alternatively, <code>#f</code> is returned if <i>port</i> does not have a
-file descriptor (a string port, for example).
-</p></blockquote>
-
+<p>Extracts the file descriptor from <i>port</i>, calls <code>dup()</code> on it,
+and invokes <i>proc</i> with a single argument, the new file descriptor.
+When <i>proc</i> returns, the file descriptor is closed.
+<b>This procedure should be used only when absolutely necessary,</b>
+such as when invoking a P<small>OSIX</small> API function
+not made available in this SRFI.
+It is an error to do a read, write, seek, or close operation on the port
+while <i>proc</i> is executing, or to let the file descriptor leak out of <i>proc</i>.
+</p>
+</blockquote>
 <h3>3.3&nbsp;&nbsp;File system</h3>
 <p>The following procedures allow access to the
 computer's file system.

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -424,7 +424,7 @@ prevent this problem; at least it is highly unlikely to occur in practice.
 <p></p>
 <div><code>(delete-directory <i>fname</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>rmdir()</code>&nbsp;</div>
 <blockquote>This procedure deletes directories from the file system.
-An exception is signaled if <i>fname</i> is not a directory or is not empty.
+An error is signaled if <i>fname</i> is not a directory or is not empty.
 </blockquote>
 <div><code>(set-file-owner <i>fname uid gid</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>chown()</code>&nbsp;</div>
 
@@ -683,14 +683,14 @@ with a varying string.<p>
 The <i>maker</i> procedure is called serially on each filename
 generated.  It must return at least one value; it may return multiple
 values. If the first return value is <code>#f</code> or if <i>maker</i> signals an
-exception indicating that the file exists
+exception indicating that the file exists,
 <code>call-with-temporary-filename</code> will loop,
 generating a new filename and calling <i>maker</i> again. If the first
 return value is true, the loop is terminated, returning whatever value(s)
 <i>maker</i> returned.</p>
 <p>
-After a number of unsuccessful trials, <code>call-with-temporary-filename</code> may give up
-and signal an error.</p>
+After a number of unsuccessful trials, <code>call-with-temporary-filename</code> may give up,
+in which case an exception is signaled or propagated.
 <p>
 To rename a file to a temporary name:
 </p>
@@ -969,15 +969,17 @@ so the suffix is kept in this SRFI.</p>
 <p></p>
 <p>
 </p>
-<div><code>(terminal? <i>port-or-fd</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code>&nbsp;</div>
+<div><code>(terminal? <i>fd</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code>&nbsp;</div>
 <blockquote>
-Returns true if the argument is a port or file descriptor
+Returns true if the argument is a file descriptor
 that is open on a terminal.
-Raises an error if <code><i>port</i></code> is not a port or an exact integer,
+Raises an error if <code><i>port</i></code> is not an exact integer,
 or if the underlying call to <code>isatty()</code> returns an error
 other than <code>ENOTTY</code>.
 This procedure is useful when writing programs that change their behavior
 when their standard input or output is a terminal.
+Note that it is safe to call this operation
+on the result of <code>fd-internal-port</code>.
 </blockquote>
 <h2>Implementation</h2>
 

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -317,6 +317,7 @@ where bytes are intended to appear from the source or at the destination as soon
 buffering with a block of implementation-dependent size;
 and buffering line by line, where a line is terminated
 by a newline byte <code>#xA</code>.
+The default is implementation-dependent.
 </blockquote>
 <div><code>(open-file <i>fname port-type flags [permission-bits [buffer-mode] ]</i>)</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp; P<small>OSIX</small> <code>open()</code></div>
 <blockquote>
@@ -344,7 +345,9 @@ Scheme world.
 The most common use of this procedure is for a file descriptor other
 than 0, 1, 2 (standard input, standard output, standard error)
 that is already open when the Scheme program starts.
-It is an error if a port already exists that encapsulates <i>fd</i>.
+It is an error if a port already exists that encapsulates <i>fd</i>,
+or if an attempt is made to use <code>fd->port</code>
+twice on the same fd.
 </p>
 </blockquote>
 

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -352,31 +352,6 @@ It is an error if a port already exists that encapsulates <i>fd</i>.
 </p>
 </blockquote>
 
-<div><code>(call-with-port-fd <i>port proc</i>)</code> &nbsp;&rarr; <i>obj... </i>&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<p></p>
-<blockquote>
-<p>Extracts the file descriptor from <i>port</i>, calls <code>dup()</code> on it,
-and invokes <i>proc</i> with a single argument, the new file descriptor.
-When <i>proc</i> returns, the file descriptor is closed
-and <code>call-with-port-fd</code> returns the value(s) that <i>proc</i> returned.
-As such, it is closely analogous to the R6RS and R7RS procedure
-<code>call-with-port</code>.</p>
-<p><b>This procedure should be used only when absolutely necessary,</b>
-such as when invoking a P<small>OSIX</small> API function
-not made available in this SRFI.
-If a read, write, or positioning operation is done on either <i>port</i>
-or the new file descriptor
-while <i>proc</i> is executing, the results are unpredictable.
-</p>
-</blockquote>
-<div><code>(close-fd <i>fd</i>)</code> &nbsp;&rarr; <i>unspecified</i>&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>close()</code></div>
-<p></p>
-<blockquote>
-Closes the file descriptor <i>fd</i>.
-<b>This procedure is dangerous</b>, and it is an error to call it
-except when cleaning up after a <code>call-with-port-id</code>
-that needs to make a non-local exit.
-</blockquote>
 <h3>3.3&nbsp;&nbsp;File system</h3>
 <p>The following procedures allow access to the
 computer's file system.

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -273,10 +273,15 @@ which can be either a simple exact integer
 or the exact integer wrapped in a
 trivial record.  The latter method makes it possible to garbage-collect
 file descriptors after all; the former method is backward compatible.
-In all cases, however, a procedure that takes an FDO argument takes an
+</p>
+<p>
+In all cases, however, a procedure in this SRFI that takes an FDO argument takes an
 exact integer as well, so that (for example) <code>(terminal? 0)</code>
 will work without the 0 being wrapped.  For that reason no
 procedure to wrap integers as FDOs is provided.
+However, a procedure to unwrap FDOs as exact integers <i>is</i> provided
+for the benefit of procedures in other SRFIs that want exact integer file descriptors.
+</p>
 <p>
 Ideally, a Scheme program could only use ports and not
 file descriptors.  But code written in any language, including Scheme,
@@ -306,11 +311,19 @@ As exceptions, <code>open-file</code> is provided, because
 it allows arguments that the Scheme standard does not.  It returns
 a file descriptor that can then be converted to a port.
 Likewise, <code>terminal?</code> in Section 3.12
-accepts an FDO because it is often
+accepts an FDO as well as a port because it is often
 applied to the standard input (fd 0), standard output (1),
 or standard error(3), and it is possible that no port is open
 on any of these.
 </p>
+<div><code>(fdo-internal-fd <i>fdo-or-exact-int</i>)</code> &nbsp;&rarr; <i>exact-int</i>&nbsp;&nbsp;</div>
+<p></p>
+<blockquote>
+<p>Returns the file descriptor encapsulated in <i>fdo</i> as an exact integer.
+<b>It should be used only when absolutely necessary.</b>
+If <i>fdo-or-exact-int</i> is an exact integer it is returned.
+</p>
+</blockquote>
 <p>
 <div><code>(open-file <i>fname flags [permission-bits]</i>)</code> &nbsp;&rarr; <i>fdo</i>&nbsp;&nbsp; P<small>OSIX</small> <code>open()</code></div>
 <blockquote>

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -203,13 +203,13 @@ This SRFI provides three procedures which will typically be shims
 over whatever the implementation uses to report such errors:
 </p>
 
-<div><code>(posix-error? <i>obj</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>boolean</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)
+<div><code>(posix-error? <i>obj</i>)</code> &nbsp;&rarr; <i>boolean</i>
 <blockquote>
 This procedure returns <code>#t</code> if <code>obj</code> is
 a condition object that describes a P<small>OSIX</small> error,
 and <code>#f</code> otherwise.
 </blockquote>
-<div><code>(posix-error-name <i>posix-error</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>symbol</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)
+<div><code>(posix-error-name <i>posix-error</i>)</code> &nbsp;&rarr; <i>symbol</i>
 <blockquote>
 <p>This procedure returns a symbol that is the name associated
 with the value of <code>errno</code> when
@@ -229,7 +229,7 @@ But <code>ETIMEDOUT</code>, meaning that a TCP connection
 has been unresponsive for too long, is standardized by P<small>OSIX</small>,
 has a <code>errno</code> value of 110 on Linux, but 60 on FreeBSD and 116 on Cygwin.</p>
 </blockquote>
-<div><code>(posix-error-message <i>posix-error</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)
+<div><code>(posix-error-message <i>posix-error</i>)</code> &nbsp;&rarr; <i>string</i>
 <blockquote>
 This procedure returns a string that is an error message reflecting
 the value of <code>errno</code> when
@@ -267,9 +267,19 @@ When a port is garbage collected, it is effectively closed,
 but whether the underlying file descriptor is closed is left as an
 implementation detail.  Because file
 descriptors are just integers, it's impossible to garbage collect them.</p>
+<p>Therefore, this SRFI introduces the concept
+of a <i>file descriptor object</i> (FDO),
+which can be either a simple exact integer
+or the exact integer wrapped in a
+trivial record.  The latter method makes it possible to garbage-collect
+file descriptors after all; the former method is backward compatible.
+In all cases, however, a procedure that takes an FDO argument takes an
+exact integer as well, so that (for example) <code>(terminal? 0)</code>
+will work without the 0 being wrapped.  For that reason no
+procedure to wrap integers as FDOs is provided.
 <p>
-If a Scheme program only used Scheme ports, and never actually used
-file descriptors, this would not be a problem. But Scheme code
+Ideally, a Scheme program could only use ports and not
+file descriptors.  But code written in any language, including Scheme,
 needs to descend to the file descriptor level in at least two circumstances:
 when interfacing to foreign code, and
 when interfacing to a subprocess.
@@ -277,10 +287,10 @@ when interfacing to a subprocess.
 This causes a problem. Suppose we have a Scheme port constructed
 on top of file descriptor 3. We intend to execute a successor program that
 will expect this file descriptor. If we drop references to the port,
-the garbage collector may prematurely close file 3 before we fork
-the subprocess.</p>
+the garbage collector may prematurely close file 3 before 
+the successor program starts.</p>
 <p>
-Unfortunately, there is no even vaguely portable solution to this problem.
+Unfortunately, there is no even vaguely portable solution to the general problem.
 Scsh and Guile undertake heroic measures to
 open new file descriptors for ports when the old file descriptors are
 repurposed for something else, and to track when closing a port implies
@@ -292,13 +302,18 @@ to provide this SRFI.</p>
 <p>Consequently, this SRFI assumes that file descriptors will only
 be used at the edges of the program, and that most I/O operations will be
 performed on ports.
-As an exception, <code>open-file</code> is provided, because
+As exceptions, <code>open-file</code> is provided, because
 it allows arguments that the Scheme standard does not.  It returns
 a file descriptor that can then be converted to a port.
+LIkewise, <code>terminal?</code> accepts an FDO because it is often
+applied to the standard input (fd 0), standard output (1),
+or standard error(3), and it is possible that no port is open
+on any of these.
 </p>
 <p>
-<div><code>(open-file <i>fname flags [permission-bits]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>fd</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>open()</code>&nbsp;</div>
+<div><code>(open-file <i>fname flags [permission-bits]</i>)</code> &nbsp;&rarr; <i>fdo</i>&nbsp;&nbsp; P<small>OSIX</small> <code>open()</code></div>
 <blockquote>
+Opens the file named by <i>fname</i> and returns an FDO.
 <i>Permission-bits</i> defaults to <code>#o666</code>, but are masked by the current umask.
 <i>Flags</i> is an integer bitmask, composed by adding together
 one or more of the following constants:
@@ -313,10 +328,10 @@ one or more of the following constants:
 <p>It is an error unless exactly one of the <code>open/read</code>, <code>open/write</code>, or
 <code>open/read+write</code> flags is provided.</p>
 </blockquote>
-<div><code>(port-internal-fd <i>port</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>fd</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(port-internal-fd <i>port</i>)</code> &nbsp;&rarr; <i>fdo</i>&nbsp;&nbsp;</div>
 <p></p>
 <blockquote>
-<p>Returns the file descriptor used by <i>port</i>,
+<p>Returns the file descriptor used by <i>port</i> as an FDO,
 or <code>#f</code> if there is no such file descriptor.
 This procedure is made available in order to invoke
 P<small>OSIX</small> functions not provided by this SRFI.
@@ -326,11 +341,11 @@ or otherwise, it is an error
 to do any further operations on <i>port</i>.
 </p>
 </blockquote>
-<div><code>(close-fd <i>fd</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>undefined</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>close()</code>&nbsp;</div>
+<div><code>(close-fd <i>fdo</i>)</code> &nbsp;&rarr; <i>undefined</i>&nbsp;&nbsp; P<small>OSIX</small> <code>close()</code></div>
 <p></p>
 <blockquote>
-<p>Closes the file descriptor <i>fd</i>.
-If <i>fd</i> is the internal file descriptor of a port, it is an error
+<p>Closes the file descriptor <i>fdo</i>.
+If <i>fdo</i> is the internal file descriptor of a port, it is an error
 to do any further operations on that port.
 </p>
 </blockquote>
@@ -351,16 +366,17 @@ the same position, so that reads and writes on one are visible from the other.
 Therefore, <b>use caution</b> when reading or writing to the file descriptor
 (something this SRFI does not provide a mechanism for doing),
 especially in the presence of buffering.</p>
-<div><code>(fd->textual-input-port <i>fd</i> [<i>buffer-mode</i>])</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>port</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<div><code>(fd->binary-input-port <i>fd</i> [<i>buffer-mode</i>])</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>port</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<div><code>(fd->textual-output-port <i>fd</i> [<i>buffer-mode</i>])</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>port</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<div><code>(fd->binary-output-port <i>fd</i> [<i>buffer-mode</i>])</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>port</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(fd->textual-input-port <i>fdo-or-exact-int</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(fd->binary-input-port <i>fdo-or-exact-int</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i> &nbsp&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(fd->textual-output-port <i>fdo-or-exact-int</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(fd->binary-output-port <i>fdo-or-exact-int</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
 <blockquote>
 <p>These procedures wrap a newly created port around a duplicate of
 the specified file descriptor, effectively importing it into the
 Scheme world.
 In particular, the textual ports use the same character encoding applied
-by default in the underlying implementation.</p>
+by default in the underlying implementation.
+Note that <i>fdo</i> may be an exact integer even if FDOs are disjoint from integers.
 <p>The <i>buffer-mode</i> argument, if present, is one of the constants <code>buffer/none</code>,
   <code>buffer/block</code> (the default), or <code>buffer/line</code>.
   When <i>buffer-mode</i> is <code>buffer/none</code>,
@@ -373,10 +389,10 @@ by default in the underlying implementation.</p>
 </p>
 </blockquote>
 
-<div><code>(port->fd <i>port</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>exact integer</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(port->fd <i>port</i>)</code> &nbsp;&rarr; <i><i>fdo</i></i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
 
 <blockquote>
-<p>This procedure returns a file descriptor that has been duplicated
+<p>This procedure returns an FDO that has been duplicated
 from <i>port</i>, effectively exporting it from the Scheme world.
 Alternatively, <code>#f</code> is returned if <i>port</i> does not have a
 file descriptor (a string port, for example).
@@ -386,10 +402,10 @@ file descriptor (a string port, for example).
 <p>The following procedures allow access to the
 computer's file system.
 <p>
-<div><code>(create-directory <i>fname [permission-bits]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>mkdir()</code>&nbsp;</div>
-<div><code>(create-fifo <i>fname [permission-bits]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>mkfifo()</code>&nbsp;</div>
-<div><code>(create-hard-link <i>old-fname new-fname</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>link()</code>&nbsp;</div>
-<div><code>(create-symlink <i>old-fname new-fname</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>symlink()</code>&nbsp;</div>
+<div><code>(create-directory <i>fname [permission-bits]</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>mkdir()</code></div>
+<div><code>(create-fifo <i>fname [permission-bits]</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>mkfifo()</code></div>
+<div><code>(create-hard-link <i>old-fname new-fname</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>link()</code></div>
+<div><code>(create-symlink <i>old-fname new-fname</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>symlink()</code></div>
 
 <blockquote><p>
 These procedures create objects of various kinds in the file system.
@@ -401,10 +417,10 @@ to <code>#o664</code>, but are masked by the current umask.
 <p>
 </p></blockquote>
 
-<div><code>(read-symlink <i>fname</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>string</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>readlink()</code>&nbsp;</div>
+<div><code>(read-symlink <i>fname</i>)</code> &nbsp;&rarr; <i><i>string</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>readlink()</code></div>
 <blockquote>Return the filename referenced by the symlink <i>fname</i>.
 </blockquote>
-<div><code>(rename-file <i>old-fname new-fname</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>rename()</code>&nbsp;</div>
+<div><code>(rename-file <i>old-fname new-fname</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>rename()</code></div>
 <blockquote>If you override an existing object, then <i>old-fname</i>
 and <i>new-fname</i> must type-match &mdash; either both directories,
 or both non-directories.
@@ -422,11 +438,11 @@ prevent this problem; at least it is highly unlikely to occur in practice.
 </blockquote><p>
 </p>
 <p></p>
-<div><code>(delete-directory <i>fname</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>rmdir()</code>&nbsp;</div>
+<div><code>(delete-directory <i>fname</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>rmdir()</code></div>
 <blockquote>This procedure deletes directories from the file system.
 An error is signaled if <i>fname</i> is not a directory or is not empty.
 </blockquote>
-<div><code>(set-file-owner <i>fname uid gid</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>chown()</code>&nbsp;</div>
+<div><code>(set-file-owner <i>fname uid gid</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>chown()</code></div>
 
 <blockquote>
 This procedure sets the owner and group of a
@@ -441,7 +457,7 @@ This procedure follows symlinks and changes the files to which they refer.
 </p>
 <p></p>
 <p></p>
-<div><code>(set-file-times <i>fname [access-time-object modify-time-object]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>utimensat()</code>&nbsp;</div>
+<div><code>(set-file-times <i>fname [access-time-object modify-time-object]</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>utimensat()</code></div>
 
 <blockquote>
 This procedure sets the access and modified times for the file
@@ -462,14 +478,14 @@ status-change (<code>ctime</code>) is set to the current time.
 <p></p>
 <p></p>
 <p></p>
-<div><code>(truncate-file <i>fname/port len</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>truncate()</code>&nbsp;</div>
+<div><code>(truncate-file <i>fname/port len</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>truncate()</code></div>
 <blockquote>The specified file is truncated to <i>len</i> bytes in length.
 </blockquote><p>
 </p>
 <p></p>
 <p></p>
 <p></p>
-<div><code>(file-info <i>fname/port follow?</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>file-info-record</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>stat()</code>&nbsp;</div>
+<div><code>(file-info <i>fname/port follow?</i>)</code> &nbsp;&rarr; <i>file-info-record</i>&nbsp;&nbsp; P<small>OSIX</small> <code>stat()</code></div>
 <blockquote>
 The <code>file-info</code> procedure
 returns a file-info record containing useful
@@ -479,23 +495,23 @@ report on the file to which they refer.  If <i>follow?</i> is false
 the procedure checks the actual file itself, even if it's a symlink.
 The <i>follow?</i> flag is ignored if the file argument is a port.
 </blockquote>
-<div><code>(file-info? <i>obj</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>boolean</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(file-info? <i>obj</i>)</code> &nbsp;&rarr; <i>boolean</i>&nbsp;&nbsp;</div>
 <blockquote>Returns <code>#t</code> if <i>obj</i> is a file-info record and <code>#f</code> otherwise.
 </blockquote>
 
-<div><code>(file-info:device <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:inode <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:mode <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:nlinks <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:uid <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:gid <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:rdev <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:size <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:blksize <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:blocks <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:atime <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>time-object</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:mtime <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>time-object</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(file-info:ctime <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>time-object</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(file-info:device <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:inode <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:mode <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:nlinks <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:uid <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:gid <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:rdev <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:size <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:blksize <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:blocks <i>file-info</i>)</code> &nbsp;&rarr; <i>integer</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:atime <i>file-info</i>)</code> &nbsp;&rarr; <i>time-object</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:mtime <i>file-info</i>)</code> &nbsp;&rarr; <i>time-object</i>&nbsp;&nbsp;</div>
+<div><code>(file-info:ctime <i>file-info</i>)</code> &nbsp;&rarr; <i>time-object</i>&nbsp;&nbsp;</div>
 <blockquote><p>Returns the device number, inode number, mode (permission and file type bits),
 number of hard links, user id, group id, device ID if file is special,
 size in bytes, optimal blocksize for I/O, number of 512B blocks allocated,
@@ -535,12 +551,12 @@ examine several bits.</p>
 
 </blockquote>
 <p></p>
-<div><code>(file-info-directory? <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISDIR()</code>&nbsp;</div>
-<div><code>(file-info-fifo? <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISFIFO()</code>&nbsp;</div>
-<div><code>(file-info-symlink? <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISLNK()</code>&nbsp;</div>
-<div><code>(file-info-regular? <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISREG()</code>&nbsp;</div>
-<div><code>(file-info-socket? <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>S_IFIFO()</code>&nbsp;</div>
-<div><code>(file-info-device? <i>file-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISCHR() || S_ISBLK()</code>&nbsp;</div>
+<div><code>(file-info-directory? <i>file-info</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISDIR()</code></div>
+<div><code>(file-info-fifo? <i>file-info</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISFIFO()</code></div>
+<div><code>(file-info-symlink? <i>file-info</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISLNK()</code></div>
+<div><code>(file-info-regular? <i>file-info</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISREG()</code></div>
+<div><code>(file-info-socket? <i>file-info</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>S_IFIFO()</code></div>
+<div><code>(file-info-device? <i>file-info</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>S_ISCHR() || S_ISBLK()</code></div>
 
 <blockquote>
 These procedures are file-type predicates that test the
@@ -560,14 +576,14 @@ However, not even root can write a file stored on a read-only file system,
 such as a CD-ROM.</p>
 </blockquote>
 <p></p>
-<div><code>(set-file-mode <i>fname mode-bits</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>chmod()</code>&nbsp;</div>
+<div><code>(set-file-mode <i>fname mode-bits</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>chmod()</code></div>
 <blockquote>
 This procedure sets the mode bits of a
 file specified by supplying the filename.
 This procedure follows symlinks and changes the files to which they refer.
 </blockquote><p>
 <p></p>
-<div><code>(directory-files <i>dir [dotfiles?]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string list</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(directory-files <i>dir [dotfiles?]</i>)</code> &nbsp;&rarr; <i>string list</i>&nbsp;&nbsp;</div>
 
 <blockquote>
 Return a list of filenames in directory <i>dir</i>.
@@ -585,7 +601,7 @@ prepend the directory,
 or change to the directory before using the filenames.
 </blockquote>
 
-<div><code>(make-directory-files-generator <i>dir [dotfiles?]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>generator</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(make-directory-files-generator <i>dir [dotfiles?]</i>)</code> &nbsp;&rarr; <i>generator</i>&nbsp;&nbsp;</div>
 
 <blockquote>
 Return a
@@ -604,9 +620,9 @@ common paradigm when using a file system as a document database.</p>
 open directory object.</p>
 </blockquote>
 
-<div><code>(open-directory <i>dir [dot-files?]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>directory-object</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>opendir()</code>&nbsp;</div>
-<div><code>(read-directory <i>directory-object</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string or eof-object</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>readdir()</code>&nbsp;</div>
-<div><code>(close-directory <i>directory-object</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>closedir()</code>&nbsp;</div>
+<div><code>(open-directory <i>dir [dot-files?]</i>)</code> &nbsp;&rarr; <i>directory-object</i>&nbsp;&nbsp; P<small>OSIX</small> <code>opendir()</code></div>
+<div><code>(read-directory <i>directory-object</i>)</code> &nbsp;&rarr; <i>string or eof-object</i>&nbsp;&nbsp; P<small>OSIX</small> <code>readdir()</code></div>
+<div><code>(close-directory <i>directory-object</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>closedir()</code></div>
 <p>
 These procedures implement an interface to the
 <code>opendir()</code>/
@@ -623,7 +639,7 @@ The <code><i>dot-files?</i></code> argument controls whether filenames beginning
 If it is <code>#f</code>, which is the default, they are not.  The filenames <code>.</code> and <code>..</code> are <i>never</i> returned.
 Finally, <code>close-directory</code> closes a directory object.</p>
 
-<div><code>(real-path <i>path</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>realpath()</code>&nbsp;</div>
+<div><code>(real-path <i>path</i>)</code> &nbsp;&rarr; <i>string</i>&nbsp;&nbsp; P<small>OSIX</small> <code>realpath()</code></div>
 
 <blockquote>
 Returns an absolute pathname
@@ -631,7 +647,7 @@ derived from <i>pathname</i> that names the same file
 and whose resolution does not involve <code>.</code>, <code>..</code>, or symlinks.
 </blockquote>
 
-<div><code>temp-file-prefix</code> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<i>string parameter</i>&nbsp;</div>
+<div><code>temp-file-prefix</code><i>string parameter</i></div>
 <p></p>
 <blockquote>
 <a href="https://srfi.schemers.org/srfi-39/srfi-39.html">SRFI 39</a>
@@ -642,7 +658,7 @@ if <code>TMPDIR</code> is set and to
 On Windows, the temporary directory's name is not fixed, and must be obtained by the
 <code>GetTempPath()</code> API function.
 </blockquote>
-<div><code>(create-temp-file <i>[prefix]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>string</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(create-temp-file <i>[prefix]</i>)</code> &nbsp;&rarr; <i><i>string</i></i>&nbsp;&nbsp;</div>
 <blockquote>Creates a new temporary file and returns its name.
 The optional argument specifies the filename prefix to use, and defaults
 to the result of invoking <code>temp-file-prefix</code>.
@@ -663,7 +679,7 @@ that collisions are less likely to occur. This speeds things up, but does
 not affect correctness.</p>
 </blockquote><p>
 </p>
-<div><code>(call-with-temporary-filename <i>maker [prefix]</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>object</i><sup>+</sup></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(call-with-temporary-filename <i>maker [prefix]</i>)</code> &nbsp;&rarr; <i><i>object</i><sup>+</sup></i>&nbsp;&nbsp;</div>
 
 <blockquote>
 This procedure can be used to perform certain atomic transactions on
@@ -728,13 +744,13 @@ or to return values other than the new filename (for example, an open port).
 <p></p>
 <p></p>
 <p></p>
-<div><code>(umask)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>exact integer</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;P<small>OSIX</small> <code>umask()</code>&nbsp;</div>
+<div><code>(umask)</code> &nbsp;&rarr; <i><i>exact integer</i></i>&nbsp;&nbsp;P<small>OSIX</small> <code>umask()</code></div>
 <blockquote>
 Returns the current file protection mask, or umask, as an exact integer.
 Whenever a file is created, the specified or default permissions are
 bitwise-anded with the complement of the umask before they are used.
 </blockquote>
-<div><code>(set-umask!&nbsp;<i>umask</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>unspecified</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;P<small>OSIX</small> <code>umask()</code>&nbsp;</div>
+<div><code>(set-umask!<i>umask</i>)</code> &nbsp;&rarr; <i><i>unspecified</i></i>&nbsp;&nbsp;P<small>OSIX</small> <code>umask()</code></div>
 <blockquote>
 <p>Sets the file protection mask to the exact integer <i>umask</i>
 and returns an unspecified value.</p>
@@ -751,13 +767,13 @@ be set in the primordial thread before any other threads are created
 </blockquote>
 <p></p>
 <p></p>
-<div><code>(current-directory)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>string</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>getcwd()</code>&nbsp;</div>
+<div><code>(current-directory)</code> &nbsp;&rarr; <i><i>string</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>getcwd()</code></div>
 <blockquote>
 Returns the current directory as a string containing an absolute pathname.
 Whenever a file is referenced with a relative path, it is interpreted as
 relative to this directory.
 </blockquote>
-<div><code>(set-current-directory!&nbsp;<i>new-directory</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>unspecified</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>chdir()</code>&nbsp;</div>
+<div><code>(set-current-directory!<i>new-directory</i>)</code> &nbsp;&rarr; <i><i>unspecified</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>chdir()</code></div>
 <blockquote>
 <p>Sets the current directory to <i>new-directory</i>
 and returns an unspecified value.</p>
@@ -774,12 +790,12 @@ be set in the primordial thread before any other threads are created
 </blockquote>
 <p></p>
 <p></p>
-<div><code>(pid<i></i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>exact integer</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>getpid()</code>&nbsp;</div>
+<div><code>(pid<i></i>)</code> &nbsp;&rarr; <i><i>exact integer</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>getpid()</code></div>
 <blockquote>
 Retrieves the process id for the current process.
 </blockquote>
 
-<div><code>(nice <i>[delta]</i>)</code> &nbsp;&nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>exact integer</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>nice()</code>&nbsp;</div>
+<div><code>(nice <i>[delta]</i>)</code>&rarr; <i><i>exact integer</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>nice()</code></div>
 <blockquote><p>
 Increments the niceness of the current process by <i>delta</i>.
 The lower the <i>niceness</i> value is, the more the process is favored during scheduling.
@@ -788,11 +804,11 @@ If <code><i>delta</i></code> is not specified, the increment is 1.
 <p>Real-time processes are not affected by <code>nice</code>.</p>
 </blockquote><p>
 </p>
-<div><code>(user-uid<i></i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>exact integer</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>getuid()</code>&nbsp;</div>
-<div><code>(user-gid<i></i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>exact integer</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>getgid()</code>&nbsp;</div>
-<div><code>(user-effective-uid<i></i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>exact integer</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>geteuid()</code>&nbsp;</div>
-<div><code>(user-effective-gid<i></i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>exact integer</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>getegid()</code>&nbsp;</div>
-<div><code>(user-supplementary-gids<i></i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>exact integer</i> list</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>getgroups()</code>&nbsp;</div>
+<div><code>(user-uid<i></i>)</code> &nbsp;&rarr; <i><i>exact integer</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>getuid()</code></div>
+<div><code>(user-gid<i></i>)</code> &nbsp;&rarr; <i><i>exact integer</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>getgid()</code></div>
+<div><code>(user-effective-uid<i></i>)</code> &nbsp;&rarr; <i><i>exact integer</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>geteuid()</code></div>
+<div><code>(user-effective-gid<i></i>)</code> &nbsp;&rarr; <i><i>exact integer</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>getegid()</code></div>
+<div><code>(user-supplementary-gids<i></i>)</code> &nbsp;&rarr; <i><i>exact integer</i> list</i>&nbsp;&nbsp; P<small>OSIX</small> <code>getgroups()</code></div>
 
 <blockquote>
 For the calling process, these routines get the specified data.  The scsh proceedure <code>user-login-name</code>, which uses <code>getlogin()</code> or <code>getlogin_r()</code>, can be simulated with <code>(user-info:name (user-info (user-uid)))</code>, using procedures that are described in the next section.
@@ -806,7 +822,7 @@ For the calling process, these routines get the specified data.  The scsh procee
 </p>
 <p></p>
 <p></p>
-<div><code>(user-info <i>uid/name</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>record</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>getpwuid/getpwnam()</code>&nbsp;</div>
+<div><code>(user-info <i>uid/name</i>)</code> &nbsp;&rarr; <i>record</i>&nbsp;&nbsp; P<small>OSIX</small> <code>getpwuid/getpwnam()</code></div>
 
 <blockquote>
 Return a <code>user-info</code> record giving the recorded information for a
@@ -818,19 +834,19 @@ and callers must be prepared to handle it.
 </blockquote><p>
 </p>
 <p></p>
-<div><code>(user-info? <i>obj</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>boolean</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(user-info? <i>obj</i>)</code> &nbsp;&rarr; <i>boolean</i>&nbsp;&nbsp;</div>
 <blockquote>Returns <code>#t</code> if <i>obj</i> is a user-info record and <code>#f</code> otherwise.
 </blockquote>
-<div><code>(user-info:name <i>user-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(user-info:uid <i>user-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>exact integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(user-info:gid <i>user-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>exact integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(user-info:home-dir <i>user-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(user-info:shell <i>user-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(user-info:name <i>user-info</i>)</code> &nbsp;&rarr; <i>string</i>&nbsp;&nbsp;</div>
+<div><code>(user-info:uid <i>user-info</i>)</code> &nbsp;&rarr; <i>exact integer</i>&nbsp;&nbsp;</div>
+<div><code>(user-info:gid <i>user-info</i>)</code> &nbsp;&rarr; <i>exact integer</i>&nbsp;&nbsp;</div>
+<div><code>(user-info:home-dir <i>user-info</i>)</code> &nbsp;&rarr; <i>string</i>&nbsp;&nbsp;</div>
+<div><code>(user-info:shell <i>user-info</i>)</code> &nbsp;&rarr; <i>string</i>&nbsp;&nbsp;</div>
 <blockquote>Returns the user name, user id, group id, home directory,
 and shell path stored in <i>user-info</i> respectively.
 An implementation returns <code>#f</code> for any unavailable items.</blockquote>
 
-<div><code>(user-info:full-name <i>user-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(user-info:full-name <i>user-info</i>)</code> &nbsp;&rarr; <i>string</i>&nbsp;&nbsp;</div>
 <blockquote>Returns the contents of the <code>pw_gecos</code> field
 stored in <i>user-info</i>.
 Although this field is not part of P<small>OSIX</small>,
@@ -840,7 +856,7 @@ It normally contains the user's full name, but may contain additional
 system-specific information;
 on Windows, it contains exactly the full name.</blockquote>
 
-<div><code>(user-info:parsed-full-name <i>user-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string list</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(user-info:parsed-full-name <i>user-info</i>)</code> &nbsp;&rarr; <i>string list</i>&nbsp;&nbsp;</div>
 <blockquote><p>Returns a parsed and expanded version of the raw string
 returned by <code>user-info:full-name</code>.
 The raw value is split on commas, creating a list of strings to be
@@ -863,7 +879,7 @@ to this user; further elements depend on
 entries in the <code>/etc/nsswitch.conf</code> file.</p>
 </blockquote>
 
-<div><code>(group-info <i>gid/name</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>record</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>getgrgid/getgrnam()</code>&nbsp;</div>
+<div><code>(group-info <i>gid/name</i>)</code> &nbsp;&rarr; <i>record</i>&nbsp;&nbsp; P<small>OSIX</small> <code>getgrgid/getgrnam()</code></div>
 
 <blockquote>
 Return a <code>group-info</code> record giving the recorded information for a
@@ -874,11 +890,11 @@ this does not constitute an error situation,
 and callers must be prepared to handle it.
 </blockquote>
 
-<div><code>(group-info? <i>obj</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>boolean</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(group-info? <i>obj</i>)</code> &nbsp;&rarr; <i>boolean</i>&nbsp;&nbsp;</div>
 <blockquote>Returns <code>#t</code> if <i>obj</i> is a group-info record and <code>#f</code> otherwise.
 </blockquote>
-<div><code>(group-info:name <i>group-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>string</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
-<div><code>(group-info:gid <i>group-info</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>exact integer</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;</div>
+<div><code>(group-info:name <i>group-info</i>)</code> &nbsp;&rarr; <i>string</i>&nbsp;&nbsp;</div>
+<div><code>(group-info:gid <i>group-info</i>)</code> &nbsp;&rarr; <i>exact integer</i>&nbsp;&nbsp;</div>
 <blockquote>Returns the group name and group id stored in <i>group-info</i>.  The list of group member ids can be retrieved with the above <code>(user-supplementary-gids)</code></blockquote>
 
 <h3 id="node_sec_3.7">3.7&nbsp;&nbsp;[Intentionally omitted]</h3>
@@ -888,7 +904,7 @@ and callers must be prepared to handle it.
 <h3 id="node_sec_3.9">3.9&nbsp;&nbsp;[Intentionally omitted]</h3>
 
 <h3 id="node_sec_3.10">3.10&nbsp;&nbsp;Time</h3>
-<div><code>(posix-time)</code> &nbsp;&nbsp;&nbsp;&nbsp;&rarr;&nbsp;&nbsp;&nbsp;<i>time-object</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>clock_gettime()</code>&nbsp;</div>
+<div><code>(posix-time)</code>&rarr;<i>time-object</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>clock_gettime()</code></div>
 
 <blockquote>
 <p>The <code>posix-time</code> procedure returns the current time as a
@@ -898,7 +914,7 @@ since the P<small>OSIX</small> epoch (midnight January
 It uses the P<small>OSIX</small> <code>CLOCK_REALTIME</code> clock.
 </blockquote>
 
-<div><code>(monotonic-time)</code> &nbsp;&nbsp;&nbsp;&nbsp;&rarr;&nbsp;&nbsp;&nbsp;<i>time-object</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>clock_gettime()</code>&nbsp;</div>
+<div><code>(monotonic-time)</code>&rarr;<i>time-object</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>clock_gettime()</code></div>
 
 <blockquote>
 <p>The <code>monotonic-time</code> procedure returns the current time as a
@@ -929,7 +945,7 @@ If a program needs to change to a different locale, the most reliable way
 is to set the <code>LANG</code> variable to a new value.
 </p>
 
-<div><code>(set-environment-variable! <i>name</i> <i>value</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>undefined</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>setenv</code></div>
+<div><code>(set-environment-variable! <i>name</i> <i>value</i>)</code> &nbsp;&rarr; <i>undefined</i>&nbsp;&nbsp; P<small>OSIX</small> <code>setenv</code></div>
 <blockquote>
 Change the value of the environment variable <i>name</i> to
 be <i>value</i>. Both <i>name</i> and <i>value</i> are strings.
@@ -941,7 +957,7 @@ Mutating <i>name</i> or <i>value</i> after the call must not change
 the name or value of the environment variable.
 </blockquote>
 
-<div><code>(delete-environment-variable! <i>name</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i>undefined</i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>unsetenv</code></div>
+<div><code>(delete-environment-variable! <i>name</i>)</code> &nbsp;&rarr; <i>undefined</i>&nbsp;&nbsp; P<small>OSIX</small> <code>unsetenv</code></div>
 <blockquote>
 Remove the environment variable <i>name</i> such that a
 subsequent <code>(get-environment-variable <i>name</i>)</code> would
@@ -969,7 +985,7 @@ so the suffix is kept in this SRFI.</p>
 <p></p>
 <p>
 </p>
-<div><code>(terminal? <i>fd</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>boolean</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code>&nbsp;</div>
+<div><code>(terminal? <i>fd</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
 <blockquote>
 Returns true if the argument is a file descriptor
 that is open on a terminal.
@@ -1008,6 +1024,8 @@ SRFI mailing list.</p>
 <p>(Why <i>quo</i>?  Because in <i>sine qua non</i>
 the pronoun is feminine, agreeing with <i>re</i> 'thing' understood,
 whereas Olin is masculine.)</p>
+
+<p>Special thanks to Alex Shinn for coming up with the idea of FDOs.
 
 <h2>Copyright</h2>
 Copyright &copy; 2019 by John Cowan.

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -324,18 +324,15 @@ The default is implementation-dependent.
 Opens the file named by <i>fname</i> and returns a port
 of the type specified by <i>port-type</i>.
 <i>Flags</i> is an integer bitmask, composed by adding together
-one or more of the following constants:
-<code>open/read</code>,
-<code>open/write</code>,
-<code>open/read+write</code>,
+any of the following constants:
 <code>open/append</code>,
 <code>open/create</code>,
 <code>open/exclusive</code>,
 <code>open/nofollow</code>,
 <code>open/truncate</code>.
+(The P<small>OSIX</small> flags O_RDONLY, R_WRONLY, and O_RDWR
+are inferred from the port type.)
 <i>Permission-bits</i> defaults to <code>#o666</code>, but are masked by the current umask.</p>
-<p>It is an error unless exactly one of the <code>open/read</code>, <code>open/write</code>, or
-<code>open/read+write</code> flags is provided.</p>
 </blockquote>
 <div><code>(fd->port <i>fd port-type</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>
 <blockquote>

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -309,7 +309,7 @@ by <code>open-file</code> or <code>fd->port</code>.
 The textual ports use the same character encoding applied
 by default in the underlying implementation.
 The symbol <code>binary-input/output</code> represents a binary port
-that allows both input and output operations, as explained in
+that allows both input and output operations, as discussed in
 <a href="https://srfi.schemers.org/srfi-181/srfi-181.html">SRFI 181</a>.
 </blockquote>
 <div><code>buffer-none</code></div>
@@ -352,18 +352,30 @@ It is an error if a port already exists that encapsulates <i>fd</i>.
 </p>
 </blockquote>
 
-<div><code>(with-port-fd <i>port proc</i>)</code> &nbsp;&rarr; <i>unspecified</i>&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup ()</code></div>
+<div><code>(call-with-port-fd <i>port proc</i>)</code> &nbsp;&rarr; <i>obj... </i>&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
 <p></p>
 <blockquote>
 <p>Extracts the file descriptor from <i>port</i>, calls <code>dup()</code> on it,
 and invokes <i>proc</i> with a single argument, the new file descriptor.
-When <i>proc</i> returns, the file descriptor is closed.
-<b>This procedure should be used only when absolutely necessary,</b>
+When <i>proc</i> returns, the file descriptor is closed
+and <code>call-with-port-fd</code> returns the value(s) that <i>proc</i> returned.
+As such, it is closely analogous to the R6RS and R7RS procedure
+<code>call-with-port</code>.</p>
+<p><b>This procedure should be used only when absolutely necessary,</b>
 such as when invoking a P<small>OSIX</small> API function
 not made available in this SRFI.
-It is an error to do a read, write, seek, or close operation on the port
-while <i>proc</i> is executing, or to let the file descriptor leak out of <i>proc</i>.
+If a read, write, or positioning operation is done on either <i>port</i>
+or the new file descriptor
+while <i>proc</i> is executing, the results are unpredictable.
 </p>
+</blockquote>
+<div><code>(close-fd <i>fd</i>)</code> &nbsp;&rarr; <i>unspecified</i>&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>close()</code></div>
+<p></p>
+<blockquote>
+Closes the file descriptor <i>fd</i>.
+<b>This procedure is dangerous</b>, and it is an error to call it
+except when cleaning up after a <code>call-with-port-id</code>
+that needs to make a non-local exit.
 </blockquote>
 <h3>3.3&nbsp;&nbsp;File system</h3>
 <p>The following procedures allow access to the

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -629,6 +629,7 @@ open directory object.</p>
 <div><code>(open-directory <i>dir [dot-files?]</i>)</code> &nbsp;&rarr; <i>directory-object</i>&nbsp;&nbsp; P<small>OSIX</small> <code>opendir()</code></div>
 <div><code>(read-directory <i>directory-object</i>)</code> &nbsp;&rarr; <i>string or eof-object</i>&nbsp;&nbsp; P<small>OSIX</small> <code>readdir()</code></div>
 <div><code>(close-directory <i>directory-object</i>)</code> &nbsp;&rarr; <i><i>undefined</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>closedir()</code></div>
+<blockquote>
 <p>
 These procedures implement an interface to the
 <code>opendir()</code>/
@@ -645,6 +646,7 @@ The <code><i>dot-files?</i></code> argument controls whether filenames beginning
 If it is <code>#f</code>, which is the default, they are not.  The filenames <code>.</code> and <code>..</code> are <i>never</i> returned.
 Finally, <code>close-directory</code> closes a directory object.</p>
 
+</blockquote>
 <div><code>(real-path <i>path</i>)</code> &nbsp;&rarr; <i>string</i>&nbsp;&nbsp; P<small>OSIX</small> <code>realpath()</code></div>
  
 <blockquote>

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -334,7 +334,7 @@ one or more of the following constants:
 <p>It is an error unless exactly one of the <code>open/read</code>, <code>open/write</code>, or
 <code>open/read+write</code> flags is provided.</p>
 </blockquote>
-<div><code>(port-internal-fd <i>port</i>)</code> &nbsp;&rarr; <i>fdo</i>&nbsp;&nbsp;</div>
+<div><code>(port-internal-fdo <i>port</i>)</code> &nbsp;&rarr; <i>fdo</i>&nbsp;&nbsp;</div>
 <p></p>
 <blockquote>
 <p>Returns the file descriptor used by <i>port</i> as an FDO
@@ -348,7 +348,7 @@ or otherwise, it is an error
 to do any further operations on <i>port</i>.
 </p>
 </blockquote>
-<div><code>(close-fd <i>fdo</i>)</code> &nbsp;&rarr; <i>undefined</i>&nbsp;&nbsp; P<small>OSIX</small> <code>close()</code></div>
+<div><code>(close-fdo <i>fdo</i>)</code> &nbsp;&rarr; <i>undefined</i>&nbsp;&nbsp; P<small>OSIX</small> <code>close()</code></div>
 <p></p>
 <blockquote>
 <p>Closes the file descriptor encapsulated by <i>fdo</i>.
@@ -395,7 +395,7 @@ by default in the underlying implementation.
 </p>
 </blockquote>
 
-<div><code>(port->fd <i>port</i>)</code> &nbsp;&rarr; <i><i>fdo</i></i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(port->fdo <i>port</i>)</code> &nbsp;&rarr; <i><i>fdo</i></i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
 
 <blockquote>
 <p>This procedure returns an FDO that has been duplicated
@@ -1014,7 +1014,7 @@ other than <code>ENOTTY</code>.
 This procedure is useful when writing programs that change their behavior
 when their standard input or output is a terminal.
 It is safe to call this operation
-on the result of <code>port-internal-fd</code>.
+on the result of <code>port-internal-fdo</code>.
 </blockquote>
 <h2>Implementation</h2>
 

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -646,11 +646,23 @@ If it is <code>#f</code>, which is the default, they are not.  The filenames <co
 Finally, <code>close-directory</code> closes a directory object.</p>
 
 <div><code>(real-path <i>path</i>)</code> &nbsp;&rarr; <i>string</i>&nbsp;&nbsp; P<small>OSIX</small> <code>realpath()</code></div>
-
+ 
 <blockquote>
 Returns an absolute pathname
 derived from <i>pathname</i> that names the same file
-and whose resolution does not involve <code>.</code>, <code>..</code>, or symlinks.
+and whose resolution does not involve dot (<code>.</code>), dot-dot (<code>..</code>), or symlinks.
+</blockquote>
+
+<div><code>(file-space <i>path-or-port</i>)</code> &nbsp;&rarr; <i>exact integer</i>&nbsp;&nbsp; P<small>OSIX</small> <code>statvfs(), fstatvfs()</code></div>
+
+<blockquote>
+Returns the amount of free space in bytes
+on the same volume as the file <i>path</i> (if it is a string)
+or the file open on <i>port</i> (if it is a port).
+This allows the application to detect if
+the disk is getting full.
+Use <i>path</i> if the file has not yet been created,
+or <i>port</i> if it is already open.
 </blockquote>
 
 <div><code>temp-file-prefix</code><i>string parameter</i></div>

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -267,20 +267,11 @@ When a port is garbage collected, it is effectively closed,
 but whether the underlying file descriptor is closed is left as an
 implementation detail.  Because file
 descriptors are just integers, it's impossible to garbage collect them.</p>
-<p>Therefore, this SRFI introduces the concept
+<p>Therefore, this SRFI introduces (or rather borrows from Chibi Scheme) the concept
 of a <i>file descriptor object</i> (FDO),
-which can be either a simple exact integer
-or the exact integer wrapped in a
-trivial record.  The latter method makes it possible to garbage-collect
-file descriptors after all; the former method is backward compatible.
-</p>
-<p>
-In all cases, however, a procedure in this SRFI that takes an FDO argument takes an
-exact integer as well, so that (for example) <code>(terminal? 0)</code>
-will work without the 0 being wrapped.  For that reason no
-procedure to wrap integers as FDOs is provided.
-However, a procedure to unwrap FDOs as exact integers <i>is</i> provided
-for the benefit of procedures in other SRFIs that want exact integer file descriptors.
+which is the exact integer representing a file descriptor
+wrapped in a trivial record.
+This approach makes it possible to garbage-collect file descriptors after all.
 </p>
 <p>
 Ideally, a Scheme program could only use ports and not
@@ -316,12 +307,13 @@ applied to the standard input (fd 0), standard output (1),
 or standard error(3), and it is possible that no port is open
 on any of these.
 </p>
-<div><code>(fdo-internal-fd <i>fdo-or-exact-int</i>)</code> &nbsp;&rarr; <i>exact-int</i>&nbsp;&nbsp;</div>
+<div><code>(fdo-internal-fd <i>fdo</i>)</code> &nbsp;&rarr; <i>exact-int</i>&nbsp;&nbsp;</div>
 <p></p>
 <blockquote>
 <p>Returns the file descriptor encapsulated in <i>fdo</i> as an exact integer.
-<b>It should be used only when absolutely necessary.</b>
-If <i>fdo-or-exact-int</i> is an exact integer it is returned.
+<b>It should be used only when absolutely necessary,</b>
+such as when invoking a P<small>OSIX</small> API function
+not made available in this SRFI.
 </p>
 </blockquote>
 <p>
@@ -359,7 +351,7 @@ to do any further operations on <i>port</i>.
 <div><code>(close-fd <i>fdo</i>)</code> &nbsp;&rarr; <i>undefined</i>&nbsp;&nbsp; P<small>OSIX</small> <code>close()</code></div>
 <p></p>
 <blockquote>
-<p>Closes the file descriptor <i>fdo</i>.
+<p>Closes the file descriptor encapsulated by <i>fdo</i>.
 If <i>fdo</i> is the internal file descriptor of a port, it is an error
 to do any further operations on that port.
 </p>
@@ -381,18 +373,16 @@ the same position, so that reads and writes on one are visible from the other.
 Therefore, <b>use caution</b> when reading or writing to the file descriptor
 (something this SRFI does not provide a mechanism for doing),
 especially in the presence of buffering.</p>
-<div><code>(fd->textual-input-port <i>fdo-or-exact-int</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<div><code>(fd->binary-input-port <i>fdo-or-exact-int</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i> &nbsp&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<div><code>(fd->textual-output-port <i>fdo-or-exact-int</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
-<div><code>(fd->binary-output-port <i>fdo-or-exact-int</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(fd->textual-input-port <i>fdo</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(fd->binary-input-port <i>fdo</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i> &nbsp&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(fd->textual-output-port <i>fdo</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
+<div><code>(fd->binary-output-port <i>fdo</i> [<i>buffer-mode</i>])</code> &nbsp;&rarr; <i>port</i>&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>dup()</code></div>
 <blockquote>
 <p>These procedures wrap a newly created port around a duplicate of
 the specified file descriptor, effectively importing it into the
 Scheme world.
 In particular, the textual ports use the same character encoding applied
 by default in the underlying implementation.
-Note that <i>fdo-or-int</i> can be an exact integer
-whether or not FDOs are disjoint from integers.
 <p>The <i>buffer-mode</i> argument, if present, is one of the constants <code>buffer/none</code>,
   <code>buffer/block</code> (the default), or <code>buffer/line</code>.
   When <i>buffer-mode</i> is <code>buffer/none</code>,
@@ -1001,7 +991,7 @@ so the suffix is kept in this SRFI.</p>
 <p></p>
 <p>
 </p>
-<div><code>(terminal? <i>port-or-fdo-or-exact-int</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
+<div><code>(terminal? <i>port-or-fdo</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
 <blockquote>
 Returns true if the argument is a port or a file descriptor
 that is open on a terminal.
@@ -1011,8 +1001,6 @@ This procedure is useful when writing programs that change their behavior
 when their standard input or output is a terminal.
 It is safe to call this operation
 on the result of <code>port-internal-fd</code>.
-The <i>port-or-fdo-or-exact-int</i> argument can be an exact integer
-whether or not FDOs are disjoint from integers.
 </blockquote>
 <h2>Implementation</h2>
 

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -305,7 +305,7 @@ performed on ports.
 As exceptions, <code>open-file</code> is provided, because
 it allows arguments that the Scheme standard does not.  It returns
 a file descriptor that can then be converted to a port.
-LIkewise, <code>terminal?</code> in Section 3.12
+Likewise, <code>terminal?</code> in Section 3.12
 accepts an FDO because it is often
 applied to the standard input (fd 0), standard output (1),
 or standard error(3), and it is possible that no port is open
@@ -990,15 +990,15 @@ so the suffix is kept in this SRFI.</p>
 </p>
 <div><code>(terminal? <i>port-or-fdo-or-exact-int</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
 <blockquote>
-Returns true if the argument is a file descriptor
-or a port that is open on a terminal.
+Returns true if the argument is a port or a file descriptor
+that is open on a terminal.
 Raises an exception if the underlying call to <code>isatty()</code> returns an error
 other than <code>ENOTTY</code>.
 This procedure is useful when writing programs that change their behavior
 when their standard input or output is a terminal.
 It is safe to call this operation
 on the result of <code>port-internal-fd</code>.
-The <i>fdo-or-exact-int</i> argument can be an exact integer,
+The <i>port-or-fdo-or-exact-int</i> argument can be an exact integer
 whether or not FDOs are disjoint from integers.
 </blockquote>
 <h2>Implementation</h2>

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -611,7 +611,7 @@ Use <i>path</i> if the file has not yet been created,
 or <i>port</i> if it is already open.
 </blockquote>
 
-<div><code>temp-file-prefix</code><i>string parameter</i></div>
+<div><code>temp-file-prefix</code>&nbsp;<i>string parameter</i></div>
 <p></p>
 <blockquote>
 <a href="https://srfi.schemers.org/srfi-39/srfi-39.html">SRFI 39</a>
@@ -714,7 +714,7 @@ Returns the current file protection mask, or umask, as an exact integer.
 Whenever a file is created, the specified or default permissions are
 bitwise-anded with the complement of the umask before they are used.
 </blockquote>
-<div><code>(set-umask!<i>umask</i>)</code> &nbsp;&rarr; <i><i>unspecified</i></i>&nbsp;&nbsp;P<small>OSIX</small> <code>umask()</code></div>
+<div><code>(set-umask!&nbsp;<i>umask</i>)</code> &nbsp;&rarr; <i><i>unspecified</i></i>&nbsp;&nbsp;P<small>OSIX</small> <code>umask()</code></div>
 <blockquote>
 <p>Sets the file protection mask to the exact integer <i>umask</i>
 and returns an unspecified value.</p>
@@ -737,7 +737,7 @@ Returns the current directory as a string containing an absolute pathname.
 Whenever a file is referenced with a relative path, it is interpreted as
 relative to this directory.
 </blockquote>
-<div><code>(set-current-directory!<i>new-directory</i>)</code> &nbsp;&rarr; <i><i>unspecified</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>chdir()</code></div>
+<div><code>(set-current-directory!&nbsp;<i>new-directory</i>)</code> &nbsp;&rarr; <i><i>unspecified</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>chdir()</code></div>
 <blockquote>
 <p>Sets the current directory to <i>new-directory</i>
 and returns an unspecified value.</p>

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -376,7 +376,8 @@ the specified file descriptor, effectively importing it into the
 Scheme world.
 In particular, the textual ports use the same character encoding applied
 by default in the underlying implementation.
-Note that <i>fdo</i> may be an exact integer even if FDOs are disjoint from integers.
+Note that <i>fdo-or-int</i> may be an exact integer
+whether or not FDOs are disjoint from integers.
 <p>The <i>buffer-mode</i> argument, if present, is one of the constants <code>buffer/none</code>,
   <code>buffer/block</code> (the default), or <code>buffer/line</code>.
   When <i>buffer-mode</i> is <code>buffer/none</code>,
@@ -985,17 +986,18 @@ so the suffix is kept in this SRFI.</p>
 <p></p>
 <p>
 </p>
-<div><code>(terminal? <i>fd</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
+<div><code>(terminal? <i>fdo-or-exact-int</i>)</code> &nbsp;&rarr; <i><i>boolean</i></i>&nbsp;&nbsp; P<small>OSIX</small> <code>isatty()</code></div>
 <blockquote>
 Returns true if the argument is a file descriptor
 that is open on a terminal.
-Raises an error if <code><i>port</i></code> is not an exact integer,
-or if the underlying call to <code>isatty()</code> returns an error
+Raises an exception if the underlying call to <code>isatty()</code> returns an error
 other than <code>ENOTTY</code>.
 This procedure is useful when writing programs that change their behavior
 when their standard input or output is a terminal.
-Note that it is safe to call this operation
+It is safe to call this operation
 on the result of <code>port-internal-fd</code>.
+The <i>fdo-or-exact-int</i> argument may be an exact integer,
+whether or not FDOs are disjoint from integers.
 </blockquote>
 <h2>Implementation</h2>
 

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -979,7 +979,7 @@ other than <code>ENOTTY</code>.
 This procedure is useful when writing programs that change their behavior
 when their standard input or output is a terminal.
 Note that it is safe to call this operation
-on the result of <code>fd-internal-port</code>.
+on the result of <code>port-internal-fd</code>.
 </blockquote>
 <h2>Implementation</h2>
 

--- a/srfi-170.html
+++ b/srfi-170.html
@@ -425,7 +425,7 @@ prevent this problem; at least it is highly unlikely to occur in practice.
 <p></p>
 <div><code>(delete-directory <i>fname</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>rmdir()</code>&nbsp;</div>
 <blockquote>This procedure deletes directories from the file system.
-It is an error if <i>fname</i> is not a directory or is not empty.
+An exception is signaled if <i>fname</i> is not a directory or is not empty.
 </blockquote>
 <div><code>(set-file-owner <i>fname uid gid</i>)</code> &nbsp;&nbsp;&nbsp;&rarr; &nbsp;&nbsp;&nbsp;<i><i>undefined</i></i> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(procedure)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; P<small>OSIX</small> <code>chown()</code>&nbsp;</div>
 

--- a/srfi/chibi-scheme/Makefile
+++ b/srfi/chibi-scheme/Makefile
@@ -34,7 +34,7 @@ all: $(COMPILED_LIBS) # $(META_FILES)
 ########################################################################
 # Tests
 
-repl:
+repl: all
 	$(CHIBI_LOCAL) -m "(srfi 170)"
 
 

--- a/srfi/chibi-scheme/NOTES.html
+++ b/srfi/chibi-scheme/NOTES.html
@@ -10,6 +10,14 @@ and build notes for scsh, in their own <code>srfi</code> subdirectories.
 This file documents the current exceptions and deviations
 of the Chibi Scheme implementation.
 </p>
+<p>
+Note generally that the Chibi implementation is completely thread-naive.
+What is more, the implementation's FDOs don't interoperate with
+those used by Chibi natively, which may cause some issues mixing
+SRFI 170 operations with SRFI 170's.  In particular, make sure to
+hold on to any port on which <code>port-internal-fdo</code> was
+called, so that the garbage collector does not close the file descriptor.
+</p>
 
 <h3>3.1&nbsp;&nbsp;Error handling</h3>
 <ul>
@@ -25,9 +33,6 @@ library call due to an error, and SRFI 170 getting the current errno.
 <li><p>
 The Chibi Scheme versions of the <code>fd->*port</code> procedures
 do not support the <i>buffer-mode</i> argument.
-</p></li>
-<li><p>
-The Chibi implementation is completely thread-naive.
 </p></li>
 </ul>
 

--- a/srfi/chibi-scheme/NOTES.html
+++ b/srfi/chibi-scheme/NOTES.html
@@ -14,7 +14,7 @@ of the Chibi Scheme implementation.
 Note generally that the Chibi implementation is completely thread-naive.
 What is more, the implementation's FDOs don't interoperate with
 those used by Chibi natively, which may cause some issues mixing
-SRFI 170 operations with SRFI 170's.  In particular, make sure to
+SRFI 170 operations with native Chibi ones.  In particular, make sure to
 hold on to any port on which <code>port-internal-fdo</code> was
 called, so that the garbage collector does not close the file descriptor.
 </p>

--- a/srfi/chibi-scheme/NOTES.html
+++ b/srfi/chibi-scheme/NOTES.html
@@ -26,6 +26,9 @@ library call due to an error, and SRFI 170 getting the current errno.
 The Chibi Scheme versions of the <code>fd->*port</code> procedures
 do not support the <i>buffer-mode</i> argument.
 </p></li>
+<li><p>
+The Chibi implementation is completely thread-naive.
+</p></li>
 </ul>
 
 <h3>3.3&nbsp;&nbsp;File system</h3>

--- a/srfi/chibi-scheme/lib/srfi/170.sld
+++ b/srfi/chibi-scheme/lib/srfi/170.sld
@@ -42,11 +42,11 @@
    open-file
    open/read open/write open/read+write
    open/append open/create open/exclusive open/nofollow open/truncate
-   port-internal-fd
-   close-fd
+   port-internal-fdo
+   close-fdo
    fd->textual-input-port fd->binary-input-port
    fd->textual-output-port fd->binary-output-port
-   port->fd
+   port->fdo
 
 
    ;; 3.3  File system

--- a/srfi/chibi-scheme/lib/srfi/170.sld
+++ b/srfi/chibi-scheme/lib/srfi/170.sld
@@ -59,29 +59,6 @@
    set-file-times time/now time/unchanged
    truncate-file
 
-   ;; Temp names for exercising
-
-   %statvfs
-   %fstatvfs
-   statvfs?
-
-   ;; Candidate names for getters
-
-   fs:bsize ;;  File system block size.
-   fs:frsize ;; Fundamental file system block size.
-   fs:blocks ;; Total number of blocks on file system in units of f_frsize.
-   fs:bfree ;;  Total number of free blocks.
-   fs:bavail ;; Number of free blocks available to non-privileged process.
-   fs:files ;; Total number of file serial numbers.
-   fs:ffree ;; Total number of free file serial numbers.
-   fs:favail ;; Number of file serial numbers available to non-privileged process.
-   fs:fsid ;; File system ID.
-   fs:flag ;; Bit mask of f_flag values.
-   fs:namemax ;; Maximum filename length.
-
-   statvfs/RDONLY
-   statvfs/ST_NOSUID
-
    file-info file-info?
    file-info:device file-info:inode file-info:mode file-info:nlinks
    file-info:uid file-info:gid file-info:rdev file-info:size
@@ -95,6 +72,18 @@
    open-directory read-directory close-directory
 
    real-path
+
+   ;; Temp names for exercising
+
+   %statvfs
+   %fstatvfs
+
+   ;; Candidate names for getters
+
+   fs:bsize ;;  File system block size.
+   fs:bavail ;; Number of free blocks available to non-privileged process.
+
+   free-space
 
    temp-file-prefix
    create-temp-file

--- a/srfi/chibi-scheme/lib/srfi/170.sld
+++ b/srfi/chibi-scheme/lib/srfi/170.sld
@@ -59,6 +59,29 @@
    set-file-times time/now time/unchanged
    truncate-file
 
+   ;; Temp names for exercising
+
+   %statvfs
+   %fstatvfs
+   statvfs?
+
+   ;; Candidate names for getters
+
+   fs:bsize ;;  File system block size.
+   fs:frsize ;; Fundamental file system block size.
+   fs:blocks ;; Total number of blocks on file system in units of f_frsize.
+   fs:bfree ;;  Total number of free blocks.
+   fs:bavail ;; Number of free blocks available to non-privileged process.
+   fs:files ;; Total number of file serial numbers.
+   fs:ffree ;; Total number of free file serial numbers.
+   fs:favail ;; Number of file serial numbers available to non-privileged process.
+   fs:fsid ;; File system ID.
+   fs:flag ;; Bit mask of f_flag values.
+   fs:namemax ;; Maximum filename length.
+
+   statvfs/RDONLY
+   statvfs/ST_NOSUID
+
    file-info file-info?
    file-info:device file-info:inode file-info:mode file-info:nlinks
    file-info:uid file-info:gid file-info:rdev file-info:size

--- a/srfi/chibi-scheme/lib/srfi/170.sld
+++ b/srfi/chibi-scheme/lib/srfi/170.sld
@@ -72,17 +72,6 @@
    open-directory read-directory close-directory
 
    real-path
-
-   ;; Temp names for exercising
-
-   %statvfs
-   %fstatvfs
-
-   ;; Candidate names for getters
-
-   fs:bsize ;;  File system block size.
-   fs:bavail ;; Number of free blocks available to non-privileged process.
-
    free-space
 
    temp-file-prefix

--- a/srfi/chibi-scheme/lib/srfi/170.sld
+++ b/srfi/chibi-scheme/lib/srfi/170.sld
@@ -166,6 +166,8 @@
                                   posix-error-number posix-error-scheme-procedure
                                   posix-error-posix-interface posix-error-data
                                   raise-posix-error)
+
+     (only (srfi 170 fdo) fdo? make-fdo fdo:fd)
      )
 
     (include-shared "170/170")

--- a/srfi/chibi-scheme/lib/srfi/170.sld
+++ b/srfi/chibi-scheme/lib/srfi/170.sld
@@ -38,6 +38,7 @@
 
    ;; 3.2  I/O
 
+   fdo-internal-fd
    open-file
    open/read open/write open/read+write
    open/append open/create open/exclusive open/nofollow open/truncate

--- a/srfi/chibi-scheme/lib/srfi/170/170.scm
+++ b/srfi/chibi-scheme/lib/srfi/170/170.scm
@@ -413,7 +413,11 @@
           (if (string? fname-or-port)
               (errno-error (errno) 'free-space 'statvfs fname-or-port)
               (errno-error (errno) 'file-file 'fstatvfs fname-or-port)))
-      (* (fs:bsize the-statvfs) (fs:bavail the-statvfs))))
+      (*
+       (cond-expand
+        (openbsd (fs:frsize the-statvfs))
+        (else (fs:bsize the-statvfs)))
+       (fs:bavail the-statvfs))))
 
 (define the-character-set "ABCDEFGHIJKLMNOPQURTUVWXYZ0123456789")
 

--- a/srfi/chibi-scheme/lib/srfi/170/170.scm
+++ b/srfi/chibi-scheme/lib/srfi/170/170.scm
@@ -2,6 +2,9 @@
 
 ;;; 3.2  I/O
 
+(define (fdo-internal-fd the-fdo)
+  the-fdo)
+
 (define (open-file fname flags . o)
   (let-optionals o ((permission-bits #o666))
     (if (not (string? fname))

--- a/srfi/chibi-scheme/lib/srfi/170/170.scm
+++ b/srfi/chibi-scheme/lib/srfi/170/170.scm
@@ -20,19 +20,19 @@
           (errno-error (errno) 'open-file 'open fname flags permission-bits)
           (make-fdo fd)))))
 
-(define (port-internal-fd the-port)
+(define (port-internal-fdo the-port)
   (if (not (port? the-port))
-      (sanity-check-error "argument must be a port" 'port-internal-fd the-port))
+      (sanity-check-error "argument must be a port" 'port-internal-fdo the-port))
   (let ((ret (port-fileno the-port)))
     (if ret
         (make-fdo ret)
         ret)))
 
-(define (close-fd the-fdo)
+(define (close-fdo the-fdo)
   (if (not (fdo? the-fdo))
-      (sanity-check-error "argument must be a file descriptor object (fdo)" 'close-fd the-fdo))
+      (sanity-check-error "argument must be a file descriptor object (fdo)" 'close-fdo the-fdo))
   (if (not (retry-if-EINTR (lambda () (%close (fdo:fd the-fdo)))))
-      (errno-error (errno) 'close-fd 'close the-fdo)))
+      (errno-error (errno) 'close-fdo 'close the-fdo)))
 
 ;; seems Chibi handles bogus fds OK, reading input returns eof, output
 ;; raises errors
@@ -66,9 +66,9 @@
       (sanity-check-error "argument must be a file descriptor object (fdo)" 'fd->binary-output-port the-fdo))
   (%file_descriptor_to_port (dup-file-descriptor the-fdo) #f #t))
 
-(define (port->fd the-port)
+(define (port->fdo the-port)
   (if (not (port? the-port))
-      (sanity-check-error "argument must be a port" 'port->fd the-port))
+      (sanity-check-error "argument must be a port" 'port->fdo the-port))
   (let ((the-original-fd (port-fileno the-port)))
     (if (not the-original-fd)
         the-original-fd

--- a/srfi/chibi-scheme/lib/srfi/170/170.scm
+++ b/srfi/chibi-scheme/lib/srfi/170/170.scm
@@ -643,21 +643,17 @@
 
 ;;; 3.12  Terminal device control
 
-(define (terminal? the-port)
-  (if (not (port? the-port))
-      (sanity-check-error "argument must be a port" 'terminal? the-port))
-  (let ((the-fd (port-internal-fd the-port)))
-    (if (not the-fd)
-        #f)
-    (begin
-      (set-errno 0)
-      (let ((ret (%isatty the-fd)))
-        (if (equal? 1 ret)
-            #t
-            (if (or (not (equal? 0 ret))
-                    (not (equal? ENOTTY (errno))))
-                (errno-error (errno) 'terminal? 'isatty the-port)
-                #f))))))
+(define (terminal? the-fd)
+  (if (or (not (fixnum? the-fd)) (< the-fd 0))
+      (sanity-check-error "argument must be a fixnum, and greater than or equal to 0" 'terminal? the-fd))
+  (set-errno 0)
+  (let ((ret (%isatty the-fd)))
+    (if (equal? 1 ret)
+        #t
+        (if (or (not (equal? 0 ret))
+                (not (equal? ENOTTY (errno))))
+            (errno-error (errno) 'terminal? 'isatty the-fd)
+            #f))))
 
 #|
 ;; All terminal procedures except for terminal? will be moved to a new

--- a/srfi/chibi-scheme/lib/srfi/170/170.scm
+++ b/srfi/chibi-scheme/lib/srfi/170/170.scm
@@ -177,16 +177,16 @@
                        0))
       (errno-error (errno) 'set-file-times 'utimensat fname atime mtime)))
 
-(define (truncate-file fname/port len)
+(define (truncate-file fname-or-port len)
   (if (not (exact-integer? len))
         (sanity-check-error "second argument must be an exact integer" 'truncate-file len))
-  (cond ((string? fname/port)
-         (if (not (retry-if-EINTR (lambda () (%truncate fname/port len))))
-             (errno-error (errno) 'truncate-file 'truncate fname/port len)))
-        ((port? fname/port)
-         (if (not (retry-if-EINTR (lambda () (%ftruncate (port-internal-fd fname/port) len))))
-             (errno-error (errno) 'truncate-file 'ftruncate fname/port len)))
-        (else (sanity-check-error "first argument must be a file name or a port" 'truncate-file fname/port len))))
+  (cond ((string? fname-or-port)
+         (if (not (retry-if-EINTR (lambda () (%truncate fname-or-port len))))
+             (errno-error (errno) 'truncate-file 'truncate fname-or-port len)))
+        ((port? fname-or-port)
+         (if (not (retry-if-EINTR (lambda () (%ftruncate (port-internal-fd fname-or-port) len))))
+             (errno-error (errno) 'truncate-file 'ftruncate fname-or-port len)))
+        (else (sanity-check-error "first argument must be a file name or a port" 'truncate-file fname-or-port len))))
 
 (cond-expand
   (windows
@@ -222,12 +222,12 @@
      (mtime file-info:mtime)
      (ctime file-info:ctime))))
 
-(define (file-info fname/port follow?)
+(define (file-info fname-or-port follow?)
   (let ((file-stat
-         (cond ((string? fname/port)
+         (cond ((string? fname-or-port)
                 (let ((the-file-info (if follow?
-                                         (%stat fname/port)
-                                         (%lstat fname/port))))
+                                         (%stat fname-or-port)
+                                         (%lstat fname-or-port))))
                   (if the-file-info
                       the-file-info
                       (errno-error (errno)
@@ -235,22 +235,22 @@
                                    (if follow?
                                        'stat
                                        'lstat)
-                                   fname/port))))
-               ((port? fname/port)
-                (let ((the-file-info (%fstat (port-internal-fd fname/port))))
+                                   fname-or-port))))
+               ((port? fname-or-port)
+                (let ((the-file-info (%fstat (port-internal-fd fname-or-port))))
                   (if the-file-info
                       the-file-info
-                      (errno-error (errno) 'file-info 'fstat fname/port follow?))))
-               (else (sanity-check-error "first argument must be a string or port" 'file-info fname/port)))))
+                      (errno-error (errno) 'file-info 'fstat fname-or-port follow?))))
+               (else (sanity-check-error "first argument must be a string or port" 'file-info fname-or-port)))))
     (if (not file-stat)
         (errno-error (errno)
                      'file-info
-                     (if (string? fname/port)
+                     (if (string? fname-or-port)
                             (if follow?
                                 'stat
                                 'lstat)
-                            'fname/port)
-                     fname/port
+                            'fname-or-port)
+                     fname-or-port
                      follow?))
     (make-file-info
      (stat:dev file-stat)

--- a/srfi/chibi-scheme/lib/srfi/170/170.scm
+++ b/srfi/chibi-scheme/lib/srfi/170/170.scm
@@ -671,7 +671,8 @@
 ;;; 3.12  Terminal device control
 
 (define (terminal? the-arg)
-  (let ((the-fd (cond ((fdo? the-arg) (fdo-internal-fd the-arg))
+  (let ((the-fd (cond ((fixnum? the-arg) the-arg)
+                      ((fdo? the-arg) (fdo-internal-fd the-arg))
                       ((port? the-arg) (port-fileno the-arg))
                       (else (sanity-check-error "argument must be a port or file descriptor object (fdo)" 'terminal? the-arg)))))
     (if (eq? #f the-fd)

--- a/srfi/chibi-scheme/lib/srfi/170/170.scm
+++ b/srfi/chibi-scheme/lib/srfi/170/170.scm
@@ -414,9 +414,7 @@
               (errno-error (errno) 'free-space 'statvfs fname-or-port)
               (errno-error (errno) 'file-file 'fstatvfs fname-or-port)))
       (*
-       (cond-expand
-        (openbsd (fs:frsize the-statvfs))
-        (else (fs:bsize the-statvfs)))
+       (fs:frsize the-statvfs)
        (fs:bavail the-statvfs))))
 
 (define the-character-set "ABCDEFGHIJKLMNOPQURTUVWXYZ0123456789")

--- a/srfi/chibi-scheme/lib/srfi/170/170.scm
+++ b/srfi/chibi-scheme/lib/srfi/170/170.scm
@@ -385,6 +385,7 @@
 (define (close-directory directory-object)
   (if (not (directory-object? directory-object))
       (sanity-check-error "argument must be a director object created by open-directory" 'close-directory directory-object))
+  ;; this flag, this check, is because the special finalizer stub c function for %closedir does nothing with errno
   (if (not (directory-object-is-open? directory-object))
       (sanity-check-error "argument must be a directory object not already closed" 'close-directory directory-object))
       (set-directory-object-is-open directory-object #f)

--- a/srfi/chibi-scheme/lib/srfi/170/170.stub
+++ b/srfi/chibi-scheme/lib/srfi/170/170.stub
@@ -280,7 +280,8 @@
 ;; fixnum 1 segfaults because I assume it's expecting a pointer.
 ;;
 ;; It returns SEXP_VOID instead of 0 or -1, and errno does not get set
-;; when it is handed an already closed DIR, which may not be its fault.
+;; when it is handed an already closed DIR because it checks to see if
+;; it's already closed the directory first.
 
 (define-c-type DIR
   finalizer: (%closedir closedir)

--- a/srfi/chibi-scheme/lib/srfi/170/170.stub
+++ b/srfi/chibi-scheme/lib/srfi/170/170.stub
@@ -213,6 +213,30 @@
   ((not windows)
    (define-c errno (%ftruncate ftruncate) (int off_t))))
 
+(define-c-int-type fsblkcnt_t) ;; probably a unsigned 64 bit integer
+(define-c-int-type fsfilcnt_t) ;; probably a unsigned 64 bit integer
+
+(define-c-struct statvfs
+    predicate: statvfs?
+  (unsigned-long f_bsize    fs_bsize    fs:bsize) ;;  File system block size.
+  (unsigned-long f_frsize   fs_frsize   fs:frsize) ;; Fundamental file system block size.
+  (fsblkcnt_t    f_blocks   fs_blocks   fs:blocks) ;; Total number of blocks on file system in units of f_frsize.
+  (fsblkcnt_t    f_bfree    fs_bfree    fs:bfree) ;;  Total number of free blocks.
+  (fsblkcnt_t    f_bavail   fs_bavail   fs:bavail) ;; Number of free blocks available to non-privileged process.
+  (fsfilcnt_t    f_files    fs_files    fs:files) ;;  Total number of file serial numbers.
+  (fsfilcnt_t    f_ffree    fs_ffree    fs:ffree) ;;  Total number of free file serial numbers.
+  (fsfilcnt_t    f_favail   fs_favail   fs:favail) ;; Number of file serial numbers available to non-privileged process.
+  (unsigned-long f_fsid     fs_fsid     fs:fsid) ;;   File system ID.
+  (unsigned-long f_flag     fs_flag     fs:flag) ;;   Bit mask of f_flag values.
+  (unsigned-long f_namemax  fs_namemax  fs:namemax) ;; Maximum filename length.
+  )
+
+(define-c-const int (statvfs/RDONLY "ST_RDONLY")) ;; Read-only file system
+(define-c-const int (statvfs/ST_NOSUID "ST_NOSUID")) ;; Does not support the semantics of the ST_ISUID and ST_ISGID file mode bits.
+
+(define-c errno (%statvfs statvfs) (string (result statvfs)))
+(define-c errno (%fstatvfs fstatvfs) (int (result statvfs)))
+
 (cond-expand
   (windows
    (c-include-verbatim "filesystem_win32_shim.c")

--- a/srfi/chibi-scheme/lib/srfi/170/170.stub
+++ b/srfi/chibi-scheme/lib/srfi/170/170.stub
@@ -275,10 +275,12 @@
 (define-c-struct dirent
   (string d_name dirent-name))
 
-;; the automagic finalizer is fragile and incomplete, handing it the
-;; fixnum 1 segfaults on Bionic Beaver.  It returns SEXP_VIOD instead
-;; of 0 or -1, and errno does not get set when handed an already
-;; closed DIR, which may not be its fault
+;; the automagic finalizer is fragile and incomplete, does not check
+;; the type/sanity of its argument at all so e.g. handing it the
+;; fixnum 1 segfaults because I assume it's expecting a pointer.
+;;
+;; It returns SEXP_VOID instead of 0 or -1, and errno does not get set
+;; when it is handed an already closed DIR, which may not be its fault.
 
 (define-c-type DIR
   finalizer: (%closedir closedir)

--- a/srfi/chibi-scheme/lib/srfi/170/170.stub
+++ b/srfi/chibi-scheme/lib/srfi/170/170.stub
@@ -218,17 +218,17 @@
 
 (define-c-struct statvfs
     predicate: statvfs?
-  (unsigned-long f_bsize    fs_bsize    fs:bsize) ;;  File system block size.
-  (unsigned-long f_frsize   fs_frsize   fs:frsize) ;; Fundamental file system block size.
-  (fsblkcnt_t    f_blocks   fs_blocks   fs:blocks) ;; Total number of blocks on file system in units of f_frsize.
-  (fsblkcnt_t    f_bfree    fs_bfree    fs:bfree) ;;  Total number of free blocks.
-  (fsblkcnt_t    f_bavail   fs_bavail   fs:bavail) ;; Number of free blocks available to non-privileged process.
-  (fsfilcnt_t    f_files    fs_files    fs:files) ;;  Total number of file serial numbers.
-  (fsfilcnt_t    f_ffree    fs_ffree    fs:ffree) ;;  Total number of free file serial numbers.
-  (fsfilcnt_t    f_favail   fs_favail   fs:favail) ;; Number of file serial numbers available to non-privileged process.
-  (unsigned-long f_fsid     fs_fsid     fs:fsid) ;;   File system ID.
-  (unsigned-long f_flag     fs_flag     fs:flag) ;;   Bit mask of f_flag values.
-  (unsigned-long f_namemax  fs_namemax  fs:namemax) ;; Maximum filename length.
+  (unsigned-long f_bsize    fs:bsize) ;;  File system block size.
+  (unsigned-long f_frsize   fs:frsize) ;; Fundamental file system block size.
+  (fsblkcnt_t    f_blocks   fs:blocks) ;; Total number of blocks on file system in units of f_frsize.
+  (fsblkcnt_t    f_bfree    fs:bfree) ;;  Total number of free blocks.
+  (fsblkcnt_t    f_bavail   fs:bavail) ;; Number of free blocks available to non-privileged process.
+  (fsfilcnt_t    f_files    fs:files) ;; Total number of file serial numbers.
+  (fsfilcnt_t    f_ffree    fs:ffree) ;; Total number of free file serial numbers.
+  (fsfilcnt_t    f_favail   fs:favail) ;; Number of file serial numbers available to non-privileged process.
+  (unsigned-long f_fsid     fs:fsid) ;; File system ID.
+  (unsigned-long f_flag     fs:flag) ;; Bit mask of f_flag values.
+  (unsigned-long f_namemax  fs:namemax) ;; Maximum filename length.
   )
 
 (define-c-const int (statvfs/RDONLY "ST_RDONLY")) ;; Read-only file system

--- a/srfi/chibi-scheme/lib/srfi/170/170.stub
+++ b/srfi/chibi-scheme/lib/srfi/170/170.stub
@@ -6,30 +6,13 @@
   (c-system-include "sys/types.h")
   (c-system-include "fcntl.h"))
  (else
-  (c-system-include "string.h")
   (c-system-include "errno.h")
-  (c-system-include "fcntl.h")
-
-;;  (c-system-include "sys/file.h") ; Only needed for BSD low level file operations?
-  (c-system-include "unistd.h")
   (c-system-include "dirent.h")
-
-  (c-system-include "sys/types.h")
+  (c-system-include "sys/statvfs.h")
   (c-system-include "sys/stat.h")
-
-  (c-system-include "sys/resource.h")
-
   (c-system-include "pwd.h")
   (c-system-include "grp.h")
-
-  (c-system-include "sys/utsname.h")
-
-  (c-system-include "signal.h")
-
   (c-system-include "time.h")
-  (c-system-include "sys/time.h")
-
-  (c-system-include "termios.h")
   ))
 
 

--- a/srfi/chibi-scheme/lib/srfi/170/170.stub
+++ b/srfi/chibi-scheme/lib/srfi/170/170.stub
@@ -217,22 +217,22 @@
 (define-c-int-type fsfilcnt_t) ;; probably a unsigned 64 bit integer
 
 (define-c-struct statvfs
-    predicate: statvfs?
+;;    predicate: statvfs?
   (unsigned-long f_bsize    fs:bsize) ;;  File system block size.
-  (unsigned-long f_frsize   fs:frsize) ;; Fundamental file system block size.
-  (fsblkcnt_t    f_blocks   fs:blocks) ;; Total number of blocks on file system in units of f_frsize.
-  (fsblkcnt_t    f_bfree    fs:bfree) ;;  Total number of free blocks.
+;;  (unsigned-long f_frsize   fs:frsize) ;; Fundamental file system block size.
+;;  (fsblkcnt_t    f_blocks   fs:blocks) ;; Total number of blocks on file system in units of f_frsize.
+;;  (fsblkcnt_t    f_bfree    fs:bfree) ;;  Total number of free blocks.
   (fsblkcnt_t    f_bavail   fs:bavail) ;; Number of free blocks available to non-privileged process.
-  (fsfilcnt_t    f_files    fs:files) ;; Total number of file serial numbers.
-  (fsfilcnt_t    f_ffree    fs:ffree) ;; Total number of free file serial numbers.
-  (fsfilcnt_t    f_favail   fs:favail) ;; Number of file serial numbers available to non-privileged process.
-  (unsigned-long f_fsid     fs:fsid) ;; File system ID.
-  (unsigned-long f_flag     fs:flag) ;; Bit mask of f_flag values.
-  (unsigned-long f_namemax  fs:namemax) ;; Maximum filename length.
+;;  (fsfilcnt_t    f_files    fs:files) ;; Total number of file serial numbers.
+;;  (fsfilcnt_t    f_ffree    fs:ffree) ;; Total number of free file serial numbers.
+;;  (fsfilcnt_t    f_favail   fs:favail) ;; Number of file serial numbers available to non-privileged process.
+;;  (unsigned-long f_fsid     fs:fsid) ;; File system ID.
+;;  (unsigned-long f_flag     fs:flag) ;; Bit mask of f_flag values.
+;;  (unsigned-long f_namemax  fs:namemax) ;; Maximum filename length.
   )
 
-(define-c-const int (statvfs/RDONLY "ST_RDONLY")) ;; Read-only file system
-(define-c-const int (statvfs/ST_NOSUID "ST_NOSUID")) ;; Does not support the semantics of the ST_ISUID and ST_ISGID file mode bits.
+;; (define-c-const int (statvfs/RDONLY "ST_RDONLY")) ;; Read-only file system
+;; (define-c-const int (statvfs/ST_NOSUID "ST_NOSUID")) ;; Does not support the semantics of the ST_ISUID and ST_ISGID file mode bits.
 
 (define-c errno (%statvfs statvfs) (string (result statvfs)))
 (define-c errno (%fstatvfs fstatvfs) (int (result statvfs)))

--- a/srfi/chibi-scheme/lib/srfi/170/170.stub
+++ b/srfi/chibi-scheme/lib/srfi/170/170.stub
@@ -218,7 +218,7 @@
 
 (define-c-struct statvfs
 ;;    predicate: statvfs?
-  (unsigned-long f_bsize    fs:bsize)  ;;  File system block size.
+;;  (unsigned-long f_bsize    fs:bsize)  ;;  File system block size.
   (unsigned-long f_frsize   fs:frsize) ;; Fundamental file system block size.
 ;;  (fsblkcnt_t    f_blocks   fs:blocks)   ;; Total number of blocks on file system in units of f_frsize.
 ;;  (fsblkcnt_t    f_bfree    fs:bfree)   ;;  Total number of free blocks.

--- a/srfi/chibi-scheme/lib/srfi/170/170.stub
+++ b/srfi/chibi-scheme/lib/srfi/170/170.stub
@@ -218,16 +218,16 @@
 
 (define-c-struct statvfs
 ;;    predicate: statvfs?
-  (unsigned-long f_bsize    fs:bsize) ;;  File system block size.
-;;  (unsigned-long f_frsize   fs:frsize) ;; Fundamental file system block size.
-;;  (fsblkcnt_t    f_blocks   fs:blocks) ;; Total number of blocks on file system in units of f_frsize.
-;;  (fsblkcnt_t    f_bfree    fs:bfree) ;;  Total number of free blocks.
+  (unsigned-long f_bsize    fs:bsize)  ;;  File system block size.
+  (unsigned-long f_frsize   fs:frsize) ;; Fundamental file system block size.
+;;  (fsblkcnt_t    f_blocks   fs:blocks)   ;; Total number of blocks on file system in units of f_frsize.
+;;  (fsblkcnt_t    f_bfree    fs:bfree)   ;;  Total number of free blocks.
   (fsblkcnt_t    f_bavail   fs:bavail) ;; Number of free blocks available to non-privileged process.
-;;  (fsfilcnt_t    f_files    fs:files) ;; Total number of file serial numbers.
-;;  (fsfilcnt_t    f_ffree    fs:ffree) ;; Total number of free file serial numbers.
-;;  (fsfilcnt_t    f_favail   fs:favail) ;; Number of file serial numbers available to non-privileged process.
-;;  (unsigned-long f_fsid     fs:fsid) ;; File system ID.
-;;  (unsigned-long f_flag     fs:flag) ;; Bit mask of f_flag values.
+;;  (fsfilcnt_t    f_files    fs:files)   ;; Total number of file serial numbers.
+;;  (fsfilcnt_t    f_ffree    fs:ffree)   ;; Total number of free file serial numbers.
+;;  (fsfilcnt_t    f_favail   fs:favail)  ;; Number of file serial numbers available to non-privileged process.
+;;  (unsigned-long f_fsid     fs:fsid)    ;; File system ID.
+;;  (unsigned-long f_flag     fs:flag)    ;; Bit mask of f_flag values.
 ;;  (unsigned-long f_namemax  fs:namemax) ;; Maximum filename length.
   )
 

--- a/srfi/chibi-scheme/lib/srfi/170/TODO.txt
+++ b/srfi/chibi-scheme/lib/srfi/170/TODO.txt
@@ -13,6 +13,9 @@ Finishing call-with-temporary-filename
 
 Needed for correctness, not production quality without this:
 
+FDOs should wrap Chibi's fileno object, not integer fds, for proper
+bookkeeping and finalization with closing the fd.
+
 errno manipulation needs to be done at the C level, for Chibi Scheme
 might set errno between any of 1) manually setting errno, 2) a POSIX
 call possibly setting it, and 3) retrieving its value.  See the SRFI

--- a/srfi/chibi-scheme/lib/srfi/170/TODO.txt
+++ b/srfi/chibi-scheme/lib/srfi/170/TODO.txt
@@ -4,6 +4,41 @@ to meld that part of SRFI 170 with (chibi filesystem) "e.g. reusing
 the same file-info record from stat so that the two libraries can
 interoperate."  So we can wait on him or whomever to fix that.
 
+Many more details from https://srfi-email.schemers.org/srfi-170/msg/15185410/
+
+On Sun, Sep 13, 2020 at 7:00 AM Shiro Kawai [redacted]
+
+> So it gets to the similar argument when we talked about the ownership of fd in fd->*-port.
+> 
+> There'll also be a thing that once we get fd->fdo (not in this srfi,
+> but we need it eventually along the line), the runtime must bookkeep
+> if other fdo is co-owning the fd; e.g. some kind of reference
+> counting per fd, or having a table so that active fd and fdo is
+> always 1:1.
+
+Yes, Chibi uses reference counting for fdo's, but there's additional
+bookkeeping to keep everything sane.
+
+All fdo objects are stored in a global weak hash table.
+fd->fdo will lookup this hash table to see if we already have the fdo.
+The FFI implicitly uses fd->fdo for procedures returning an fd.
+
+fd->*port will link the fdo to a field in the resulting port, so that it won't be gc'ed.
+In addition, we increment the ref count in the fdo.
+When a port is closed, it decements the ref count, and if the count reaches 0 we close the fdo.
+Either of the fdo and/or the port can be flagged as non-closing, for objects not managed by Scheme.
+
+close-fd closes absolutely, ignoring the count.
+
+open-[binary-]input-file calls fopen and creates a port backed by a FILE*.
+In the common case we don't care about the fdo, so it isn't reified by default.
+However, if that FILE* was already backed by an fd with a known fdo, we link it.
+
+In the event that an fd is closed outside of Scheme (via a native C call
+that knows nothing about the Scheme fdos), and subsequently reallocated
+while the fdo still exists, bad things will happen.  Don't do that.
+
+
 Needed to match the SRFI:
 
 The optional buffer-mode argument to fdes->[textual|binary]-[input|output]-port

--- a/srfi/chibi-scheme/lib/srfi/170/TODO.txt
+++ b/srfi/chibi-scheme/lib/srfi/170/TODO.txt
@@ -1,3 +1,9 @@
+BUG per Alex Shinn: "Chibi tracks fd's with a weak hash table
+internally, which your low-level wrappers are bypassing."  He's going
+to meld that part of SRFI 170 with (chibi filesystem) "e.g. reusing
+the same file-info record from stat so that the two libraries can
+interoperate."  So we can wait on him or whomever to fix that.
+
 Needed to match the SRFI:
 
 The optional buffer-mode argument to fdes->[textual|binary]-[input|output]-port

--- a/srfi/chibi-scheme/lib/srfi/170/TODO.txt
+++ b/srfi/chibi-scheme/lib/srfi/170/TODO.txt
@@ -26,6 +26,10 @@ more details: https://srfi-email.schemers.org/srfi-199/
 
 Suggested enhancements:
 
+Leverage the existing fileno object for File Descriptor Objects
+(FDOs).  They're pretty much everything FDOs need, including
+closing the fd finalization on GC.
+
 Make appropriate procedures thread safe or thread aware
 
 Improve temp-file-prefix specification and perhaps implementation

--- a/srfi/chibi-scheme/lib/srfi/170/fdo.scm
+++ b/srfi/chibi-scheme/lib/srfi/170/fdo.scm
@@ -1,0 +1,8 @@
+;; please see copyright notice in ./COPYING
+
+;; Note this should be wrapping Chibi's fileno object, but there are enough complexities to that it'll probably have to wait until Alex Shinn can spare the attention.
+
+(define-record-type File-Descriptor-Object
+  (make-fdo fd)
+    fdo?
+  (fd fdo:fd))

--- a/srfi/chibi-scheme/lib/srfi/170/fdo.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/fdo.sld
@@ -1,0 +1,21 @@
+;; please see copyright notice in 198/COPYING
+
+;; File Descriptor Objects
+
+;; Must be a library so test.sld has the same type of record to check
+;; against, wants to be a seperate library so other libraries like
+;; SRFI 205 can use FDO.
+
+(define-library (srfi 170 fdo)
+  (export fdo?
+          make-fdo
+          fdo:fd
+          )
+
+  (import
+   (scheme base)
+
+   )
+
+  (include "fdo.scm")
+  )

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -17,6 +17,7 @@
   (import (scheme base)
 
           (chibi)
+          (only (chibi ast) gc)
           (only (chibi filesystem) file-exists? delete-file)
           (chibi optional) ;; Snow package for optional args
           (only (chibi process) exit)
@@ -835,6 +836,8 @@
         (test-group "Epilogue: set-priority to 1, 2, 4"
 
           (close-port the-string-port)
+
+          (test-not-error (gc)) ;; see if we blow up
 
           ;; in epilogue so most testing is not slowed down
 

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -34,6 +34,7 @@
           (srfi 170)
 
           (srfi 170 posix-error)
+          (srfi 170 fdo)
           )
 
   (include-shared "170")

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -279,16 +279,16 @@
 
         (test-group "3.2  I/O"
 
-          (test "a" (fdo-internal-fd "a")) ;; for FDOs as unwrapped integers
+          (test-error (fdo-internal-fd "a"))
 
           (test-error (open-file 1 1 1))
           (test-error (open-file "foo" "bar" 1))
           (test-error (open-file "foo" 1 "baz"))
           (test-error (open-file bogus-path open/read))
 
-          (test 0 (port-internal-fd (current-input-port)))
-          (test 1 (port-internal-fd (current-output-port)))
-          (test 2 (port-internal-fd (current-error-port)))
+          (test 0 (fdo-internal-fd (port-internal-fd (current-input-port))))
+          (test 1 (fdo-internal-fd (port-internal-fd (current-output-port))))
+          (test 2 (fdo-internal-fd (port-internal-fd (current-error-port))))
           (test-not (port-internal-fd the-string-port))
 
           (test-error (close-fd "a"))
@@ -330,12 +330,12 @@
             (test-not-error (close-port the-port))
             (test-not-error (close-fd new-fd)))
 
-          (let ((new-fd (port->fd (current-input-port))))
+          (let ((new-fd (fdo-internal-fd (port->fd (current-input-port)))))
             (test-assert (fixnum? new-fd))
             (test-assert (> new-fd 2))
             (test 3 new-fd) ;; a bit dangerous, but on normal systems, if all of the above worked, should be true.
             (test-assert (not (eq? 0 new-fd)))
-            (test-not-error (close-fd new-fd)))
+            (test-not-error (close-fd (make-fdo new-fd))))
           (test-not (port-internal-fd the-string-port))
 
 
@@ -803,7 +803,6 @@
           (test-error (terminal? "a"))
           (test-error (terminal? #f)) ;; in case port-internal-fd returns this, like for a string port
           (test-assert (terminal? (current-input-port)))
-          (test-assert (terminal? 0))
           (test-assert (terminal? (port-internal-fd (current-input-port))))
           (test-not (terminal? the-string-port))
           (let ((port-not-terminal (open-input-file tmp-file-1)))

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -277,6 +277,8 @@
 
         (test-group "3.2  I/O"
 
+          (test "a" (fdo-internal-fd "a")) ;; for FDOs as unwrapped integers
+
           (test-error (open-file 1 1 1))
           (test-error (open-file "foo" "bar" 1))
           (test-error (open-file "foo" 1 "baz"))

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -833,7 +833,7 @@
           ) ;; end terminal device control
 
 
-        (test-group "Epilogue: set-priority to 1, 2, 4"
+        (test-group "Epilogue: cleanup, force a gc, set-priority to 1, 2, 4"
 
           (close-port the-string-port)
 

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -78,8 +78,8 @@
 
     (define starting-dir (current-directory))
 
-    (define no-dot (list-sort string<? '("fifo" "file-1" "hard-link" "symlink")))
-    (define with-dot (list-sort string<? '(".dot-file" "fifo" "file-1" "hard-link" "symlink")))
+    (define no-dot (list-sort string<? '("dir-1" "fifo" "file-1" "hard-link" "symlink")))
+    (define with-dot (list-sort string<? '("dir-1" ".dot-file" "fifo" "file-1" "hard-link" "symlink")))
 
     (define over-max-path "/tmp/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
@@ -146,6 +146,8 @@
         (test-group "3.1  Errors"
 
           ;; tests from old SRFI 198 implementation
+
+          (test #f (posix-error? 1))
 
           (set! the-error (make-posix-error 1))
           (test 'error (posix-error-error-set the-error))
@@ -219,7 +221,6 @@
 
 
           ;; tests using the above
-
           (test 0 (errno))
           (test-not-error (set-errno E2BIG))
           (set-errno E2BIG)
@@ -505,6 +506,21 @@
                                 (time? ctime)
                                 (> (time-second ctime) 0)
                                 (> (time-nanosecond ctime) 0)))))
+          (test-not-error (create-directory tmp-dir-1))
+          (test-not-error (set-file-times tmp-dir-1)) ;; "now" for both
+          (let ((fi (file-info tmp-dir-1 #t)))
+            (let ((atime (file-info:atime fi))
+                  (mtime (file-info:mtime fi))
+                  (ctime (file-info:ctime fi)))
+              (test-assert (and (time? atime)
+                                (> (time-second atime) 0)
+                                (> (time-nanosecond atime) 0)
+                                (time? mtime)
+                                (> (time-second mtime) 0)
+                                (> (time-nanosecond mtime) 0)
+                                (time? ctime)
+                                (> (time-second ctime) 0)
+                                (> (time-nanosecond ctime) 0)))))
 
           (test the-text-string-length (file-info:size (file-info tmp-file-1  #t)))
           (test-not-error (truncate-file tmp-file-1 30))
@@ -653,17 +669,17 @@
             (test the-prefix (string-copy the-filename 0 (string-length the-prefix)))
             (test-not-error (delete-file the-filename))) ;; cleaning up after self, but bad for debugging
 
-          (parameterize ((temp-file-prefix tmp-dir-1))
+          (parameterize ((temp-file-prefix tmp-file-1))
             (let ((the-filename (create-temp-file))
-                  (the-prefix (string-append tmp-dir-1 ".")))
-            (test-assert (file-exists? the-filename))
-            (test the-prefix (string-copy the-filename 0 (string-length the-prefix)))
-            (test-not-error (delete-file the-filename)))) ;; cleaning up after self, but bad for debugging
+                  (the-prefix (string-append tmp-file-1 ".")))
+              (test-assert (file-exists? the-filename))
+              (test the-prefix (string-copy the-filename 0 (string-length the-prefix)))
+              (test-not-error (delete-file the-filename)))) ;; cleaning up after self, but bad for debugging
 
           (if (not (equal? 0 (user-effective-uid)))
               (test-error (create-temp-file bogus-path)))
 
-          ;; call-with-temporary-filename
+          ;; ~~~ call-with-temporary-filename
 
           ) ;; end file system
 
@@ -759,6 +775,7 @@
 
           (test-error (terminal? -1))
           (test-error (terminal? "a"))
+          (test-error (terminal? #f)) ;; in case port-internal-fd returns this, like for a string port
           (test-error (terminal? (current-input-port)))
           (test-assert (terminal? 0))
           (test-assert (terminal? (port-internal-fd (current-input-port))))

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -286,17 +286,17 @@
           (test-error (open-file "foo" 1 "baz"))
           (test-error (open-file bogus-path open/read))
 
-          (test 0 (fdo-internal-fd (port-internal-fd (current-input-port))))
-          (test 1 (fdo-internal-fd (port-internal-fd (current-output-port))))
-          (test 2 (fdo-internal-fd (port-internal-fd (current-error-port))))
-          (test-not (port-internal-fd the-string-port))
+          (test 0 (fdo-internal-fd (port-internal-fdo (current-input-port))))
+          (test 1 (fdo-internal-fd (port-internal-fdo (current-output-port))))
+          (test 2 (fdo-internal-fd (port-internal-fdo (current-error-port))))
+          (test-not (port-internal-fdo the-string-port))
 
-          (test-error (close-fd "a"))
-          (test-error (close-fd -1))
+          (test-error (close-fdo "a"))
+          (test-error (close-fdo -1))
 
           (let* ((dev-zero-fd (open-file "/dev/zero" open/read)))
-            (test-not-error (close-fd dev-zero-fd))
-            (test-error (close-fd dev-zero-fd)))
+            (test-not-error (close-fdo dev-zero-fd))
+            (test-error (close-fdo dev-zero-fd)))
 
           (test-error (fd->textual-input-port "a"))
           (test-error (fd->textual-input-port -1))
@@ -311,32 +311,32 @@
                  (the-port (fd->binary-output-port new-fd)))
             (test-not-error (write-bytevector the-binary-bytevector the-port))
             (test-not-error (close-port the-port))
-            (test-not-error (close-fd new-fd)))
+            (test-not-error (close-fdo new-fd)))
           (let* ((new-fd (open-file tmp-file-1 open/read))
                  (the-port (fd->binary-input-port new-fd)))
             (test-assert (equal? the-binary-bytevector (read-bytevector the-binary-bytevector-length the-port)))
             (test-assert (eof-object? (read-char the-port)))
             (test-not-error (close-port the-port))
-            (test-not-error (close-fd new-fd)))
+            (test-not-error (close-fdo new-fd)))
           (let* ((new-fd (open-file tmp-file-1 open-write-create-truncate))
                  (the-port (fd->textual-output-port new-fd)))
             (test-not-error (write-string the-text-string the-port))
             (test-not-error (close-port the-port))
-            (test-not-error (close-fd new-fd)))
+            (test-not-error (close-fdo new-fd)))
           (let* ((new-fd (open-file tmp-file-1 open/read))
                  (the-port (fd->textual-input-port new-fd)))
             (test-assert (equal? the-text-string (read-string the-text-string-length the-port)))
             (test-assert (eof-object? (read-char the-port)))
             (test-not-error (close-port the-port))
-            (test-not-error (close-fd new-fd)))
+            (test-not-error (close-fdo new-fd)))
 
-          (let ((new-fd (fdo-internal-fd (port->fd (current-input-port)))))
+          (let ((new-fd (fdo-internal-fd (port->fdo (current-input-port)))))
             (test-assert (fixnum? new-fd))
             (test-assert (> new-fd 2))
             (test 3 new-fd) ;; a bit dangerous, but on normal systems, if all of the above worked, should be true.
             (test-assert (not (eq? 0 new-fd)))
-            (test-not-error (close-fd (make-fdo new-fd))))
-          (test-not (port-internal-fd the-string-port))
+            (test-not-error (close-fdo (make-fdo new-fd))))
+          (test-not (port-internal-fdo the-string-port))
 
 
           ) ;; end I/O
@@ -801,13 +801,13 @@
 
           (test-error (terminal? -1))
           (test-error (terminal? "a"))
-          (test-error (terminal? #f)) ;; in case port-internal-fd returns this, like for a string port
+          (test-error (terminal? #f)) ;; in case port-internal-fdo returns this, like for a string port
           (test-assert (terminal? (current-input-port)))
-          (test-assert (terminal? (port-internal-fd (current-input-port))))
+          (test-assert (terminal? (port-internal-fdo (current-input-port))))
           (test-not (terminal? the-string-port))
           (let ((port-not-terminal (open-input-file tmp-file-1)))
             (test-not (terminal? port-not-terminal))
-            (test-not (terminal? (port-internal-fd port-not-terminal)))
+            (test-not (terminal? (port-internal-fdo port-not-terminal)))
             (close-port port-not-terminal))
 
 #|

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -757,9 +757,13 @@
 
         (test-group "3.12  Terminal device control"
 
-          (test-assert (terminal? (current-input-port)))
+          (test-error (terminal? -1))
+          (test-error (terminal? "a"))
+          (test-error (terminal? (current-input-port)))
+          (test-assert (terminal? 0))
+          (test-assert (terminal? (port-internal-fd (current-input-port))))
           (let ((port-not-terminal (open-input-file tmp-file-1)))
-            (test-not (terminal? port-not-terminal))
+            (test-not (terminal? (port-internal-fd port-not-terminal)))
             (close-port port-not-terminal))
 
 #|

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -804,6 +804,7 @@
           (test-error (terminal? #f)) ;; in case port-internal-fdo returns this, like for a string port
           (test-assert (terminal? (current-input-port)))
           (test-assert (terminal? (port-internal-fdo (current-input-port))))
+          (test-assert (terminal? 0))
           (test-not (terminal? the-string-port))
           (let ((port-not-terminal (open-input-file tmp-file-1)))
             (test-not (terminal? port-not-terminal))

--- a/srfi/chibi-scheme/lib/srfi/170/test.sld
+++ b/srfi/chibi-scheme/lib/srfi/170/test.sld
@@ -776,10 +776,12 @@
           (test-error (terminal? -1))
           (test-error (terminal? "a"))
           (test-error (terminal? #f)) ;; in case port-internal-fd returns this, like for a string port
-          (test-error (terminal? (current-input-port)))
+          (test-assert (terminal? (current-input-port)))
           (test-assert (terminal? 0))
           (test-assert (terminal? (port-internal-fd (current-input-port))))
+          (test-not (terminal? the-string-port))
           (let ((port-not-terminal (open-input-file tmp-file-1)))
+            (test-not (terminal? port-not-terminal))
             (test-not (terminal? (port-internal-fd port-not-terminal)))
             (close-port port-not-terminal))
 

--- a/srfi/scsh/NOTES.html
+++ b/srfi/scsh/NOTES.html
@@ -24,8 +24,6 @@ because it uses specialized syntax to catch system errors.
 <h3>3.2&nbsp;&nbsp;I/O</h3>
 <ul>
 <li><p>
-</p></li>
-<li><p>
 Scsh does not distinguish between textual and binary ports,
 so there are only two procedures to convert file descriptors to ports,
 <code>fdes->inport</code> in place of <code>fd->textual-input-port</code>
@@ -34,12 +32,14 @@ and <code>fd->binary-input-port</code>, and
 and <code>fd->binary-output-port</code>.
 </p></li>
 <li><p>
-The scsh versions of the <code>fdes->*port</code> procedures
+The scsh versions of the <code>fd->*port</code> procedures
+are named <code>fdes->*port</code>, and
 do not support the <i>buffer-mode</i> argument.
 </p></li>
-<li><p>The <code>port-fd</code> procedure is called <code>port->fdes</code> in scsh.
+<li><p>The <code>port-internal-fd</code> procedure is called <code>port->fdes</code> in scsh.
 The name was changed because the use of the arrow suggests a conversion of the
 port to a file descriptor, which is not the case.
+There is no equivalent of SRFI 170's <code>port->fd</code>.
 </p></li>
 <li><p>There is no <code>close-fd</code> procedure in scsh, as the standard <code>close-port</code>
 procedure suffices.
@@ -137,7 +137,8 @@ Scsh specifies but does not implement <code>nice</code>.
   Scsh does not provide <code>posix-time</code>, but it is easily defined using the procedures
   <code>time+ticks</code> and <code>ticks/sec</code>.  The first procedure returns two values, the Posix
   second and the subsecond time in ticks; the second procedure specifies how many ticks
-  a second contains.  These are easily converted to seconds and nanoseconds.
+  a second contains.  These are easily converted to seconds and nanoseconds
+and from there to a SRFI 19 time object.
 </p></li>
 </ul>
 
@@ -145,8 +146,15 @@ Scsh specifies but does not implement <code>nice</code>.
 <h3>3.11&nbsp;&nbsp;Environment variables</h3>
 <ul>
 <li><p>
-  Scsh's <code>set-environment-variable!</code> is <code>setenv</code>, and does not signal an error in
+  Scsh's <code>set-environment-variable!</code> is named <code>setenv</code>, and does not signal an error in
   any way if it fails.  It does not implement any equivalent to <code>delete-environment-variable!</code>
+</p></li>
+</ul>
+
+<h3>12&nbsp;&nbsp;Terminal device control</h3>
+<ul>
+<li><p>
+  Scsh's <code>terminal?</code> is named <code>tty?</code>.
 </p></li>
 </ul>
 


### PR DESCRIPTION
Substantive changes: `open-file` now accepts port-type and buffer-type arguments and returns a port, and `fd->port` is now a single procedure that accepts a port-type argument.