### PR TITLE
Wrong links

### DIFF
--- a/srfi-170.html
+++ b/srfi-170.html
@@ -968,10 +968,10 @@ and build notes for scsh, in their own <code>srfi</code> subdirectories.
 Notes on the exceptions and deviations between this SRFI and
 the Chibi implementation can be found in those subdirectories, at
 <a href="https://github.com/scheme-requests-for-implementation/srfi-170/blob/master/srfi/scsh/NOTES.html">
-<code>srfi/chibi-scheme/NOTES.html</code></a>,
+<code>srfi/scsh/NOTES.html</code></a>,
 and between this SRFI and scsh 0.7 in
 <a href="https://github.com/scheme-requests-for-implementation/srfi-170/blob/master/srfi/chibi-scheme/NOTES.html">
-<code>srfi/scsh/NOTES.html</code></a>.
+<code>srfi/chibi-scheme/NOTES.html</code></a>.
 </p>
 
 <h2>Acknowledgements</h2>


### PR DESCRIPTION
The links for `srfi/scsh/NOTES.html` and `srfi/chibi-scheme/NOTES.html` are swapped.